### PR TITLE
Add ty to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,11 @@ ci:
     - mypy
     - mypy-docs
     - pylint
+    - pylint-docs
     - pyproject-fmt-fix
     - pyright
     - pyright-docs
+    - pyright-verifytypes
     - pyroma
     - ruff-check-fix
     - ruff-check-fix-docs
@@ -31,6 +33,8 @@ ci:
     - shfmt
     - shfmt-docs
     - sphinx-lint
+    - ty
+    - ty-docs
     - vulture
     - vulture-docs
     - yamlfix
@@ -166,6 +170,24 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
+        language: python
+        types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
 
       - id: vulture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ optional-dependencies.dev = [
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "tomli==2.3.0",
+    "ty==0.0.1a34",
     "vulture==2.14",
     "yamlfix==1.19.0",
 ]


### PR DESCRIPTION
## Summary
- Add ty and ty-docs hooks to pre-commit configuration
- Add ty to dev dependencies

## Test plan
- CI checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ty` and `ty-docs` pre-commit hooks and includes `ty` in dev dependencies; updates CI skip list accordingly.
> 
> - **Pre-commit**:
>   - Add `ty` and `ty-docs` hooks (pre-push) using `uv run` entries.
> - **CI**:
>   - Add `ty`, `ty-docs`, `pylint-docs`, and `pyright-verifytypes` to `ci.skip` in `.pre-commit-config.yaml`.
> - **Dependencies**:
>   - Add `ty==0.0.1a34` to `optional-dependencies.dev` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa5e0f142e551d4f9ec49de582446038bde02c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->