### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,9 @@ jobs:
 
       - name: Lint
         run: |
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage manual --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
+          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ ci:
     - yamlfix
     - zizmor
 
-default_install_hook_types: [pre-commit, pre-push, commit-msg]
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: meta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.dev = [
     "docformatter==1.7.7",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
-    "pre-commit==4.5.1",
+    "prek==0.2.25",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
     "pyproject-fmt==2.11.1",


### PR DESCRIPTION
Replace pre-commit with prek for running hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches hook execution from `pre-commit` to `prek` across the repo.
> 
> - Update GitHub Actions `lint.yml` to run `uv run --extra=dev prek run` for `pre-commit`, `pre-push`, and `manual` stages
> - Replace `pre-commit` with `prek==0.2.25` in `pyproject.toml` dev dependencies
> - Adjust `.pre-commit-config.yaml` `default_install_hook_types` to `[pre-commit, pre-push]` (drops `commit-msg`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2fb71f06b209a77a071a2a4dd05029c2f9e2f31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->