### PR TITLE
Make zizmor collection strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -308,7 +308,7 @@ repos:
 
       - id: zizmor
         name: zizmor
-        entry: uv run --extra=dev zizmor .github
+        entry: uv run --extra=dev zizmor --strict-collection .github
         language: python
         pass_filenames: false
         types_or: [yaml]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens GitHub workflow linting in pre-commit.
> 
> - Updates `zizmor` hook to run with `--strict-collection` against `.github` (`.pre-commit-config.yaml`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a086125da6186b0bef4c48bf83616a95e746c685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->