### PR TITLE
Fix zizmor warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Release
 
 on: workflow_dispatch
@@ -59,8 +58,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}"
+          replace: |-
+            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use YAML block scalar syntax for replace field to fix zizmor warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the changelog update step in the release workflow by using a YAML block scalar for multiline replacement text.
> 
> - In `.github/workflows/release.yml`, changes `replace` to a block scalar (`|-`) in the `gha-find-replace` step, ensuring the inserted changelog section (version + underline + newline) is handled as multiline and resolving the zizmor warning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ffc2ccc57074d975c1b8a9fa3331eebfb788ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->