### PR TITLE
Fix block scalar newline interpretation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: |-
-            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
+          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
+            \ }}\n"
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
The previous fix used a YAML block scalar (`|-`) which doesn't interpret `\n` as newlines, causing literal `\n` to appear in CHANGELOG.rst. This fix uses a double-quoted string on a single line which correctly interprets escape sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures proper newline insertion when updating the changelog during releases.
> 
> - In `.github/workflows/release.yml`, change the `gha-find-replace` `replace` value from a YAML block scalar to a double-quoted single-line string so `\n` is interpreted as newlines, fixing literal `\n` appearing in `CHANGELOG.rst`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efca0a2e0627e2600394d45f18408f4a9f4d5ed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->