### PR TITLE
Use literal block scalar for changelog replace string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,12 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}\n"
+          replace: |
+            Next
+            ----
+
+            ${{ steps.calver.outputs.release }}
+            ${{ steps.changelog_underline.outputs.underline }}
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use literal block scalar (`|`) with actual newlines instead of escape sequences in the release workflow. This fixes zizmor warnings while being compatible with yamlfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the release workflow to use a YAML literal block for the changelog replacement payload.
> 
> - In `.github/workflows/release.yml`, changes `replace` from a quoted string with escaped newlines to a `|` block containing actual newlines for the `gha-find-replace` step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de31354c4090971c53e140cc2754372268464644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->