### PR TITLE
Use bash shell for Lint step to ensure early failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Lint
 
 on:
@@ -16,7 +15,6 @@ permissions: {}
 
 jobs:
   build:
-
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
@@ -36,6 +34,9 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
           uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose


### PR DESCRIPTION
PowerShell does not fail on intermediate command failures by default. By using bash shell, we ensure that any failing command causes the step to fail immediately.

See https://github.com/adamtheturtle/doccmd/pull/720 for the original learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures linting fails fast by running the `Lint` step with `bash` instead of the default shell.
> 
> - Sets `shell: bash` for the `Lint` step in `.github/workflows/lint.yml` with explanatory comments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dab77b8ce6d82cf8b7d07644fe7ce9b6b5bacbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->