### PR TITLE
Replace docformatter with pydocstringformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ ci:
     - check-manifest
     - deptry
     - doc8
-    - docformatter
+    - pydocstringformatter
     - interrogate
     - interrogate-docs
     - mypy
@@ -83,9 +83,9 @@ repos:
         types_or: [yaml]
         additional_dependencies: [uv==0.9.5]
 
-      - id: docformatter
-        name: docformatter
-        entry: uv run --extra=dev -m docformatter --in-place
+      - id: pydocstringformatter
+        name: pydocstringformatter
+        entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
         additional_dependencies: [uv==0.9.5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ optional-dependencies.dev = [
     "deptry==0.24.0",
     "doc8==2.0.0",
     "doccmd==2026.1.23.4",
-    "docformatter==1.7.7",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "prek==0.3.0",
+    "pydocstringformatter==0.7.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
     "pyproject-fmt==2.11.1",
@@ -111,8 +111,8 @@ lint.select = [
 lint.ignore = [
     # Ruff warns that this conflicts with the formatter.
     "COM812",
-    # Allow our chosen docstring line-style - no one-line summary.
-    "D200",
+    # Allow our chosen docstring line-style - pydocstringformatter handles formatting
+    # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
     "D212",
     # Ruff warns that this conflicts with the formatter.
@@ -120,6 +120,14 @@ lint.ignore = [
     # Ignore "too-many-*" errors as they seem to get in the way more than
     # helping.
     "PLR0913",
+]
+
+lint.per-file-ignores."doccmd_*.py" = [
+    # Allow our chosen docstring line-style - pydocstringformatter handles
+    # formatting but docstrings in docs may not match this style.
+    "D200",
+    # Allow asserts in docs.
+    "S101",
 ]
 
 lint.per-file-ignores."tests/*" = [
@@ -254,9 +262,6 @@ spelling-private-dict-file = 'spelling_private_dict.txt'
 # --spelling-private-dict-file option instead of raising a message.
 spelling-store-unknown-words = 'no'
 
-[tool.docformatter]
-make-summary-multi-line = true
-
 [tool.check-manifest]
 
 ignore = [
@@ -341,6 +346,12 @@ typeCheckingMode = "strict"
 # This defines as a constant a variable in the ``mypy`` source code which is
 # used to configure a type hint.
 defineConstant = { MYPYC = false }
+
+[tool.pydocstringformatter]
+write = true
+split-summary-body = false
+max-line-length = 75
+linewrap-full-docstring = true
 
 [tool.interrogate]
 fail-under = 100

--- a/src/mypy_strict_kwargs/__init__.py
+++ b/src/mypy_strict_kwargs/__init__.py
@@ -1,6 +1,4 @@
-"""
-``mypy`` plugin to enforce strict keyword arguments.
-"""
+"""``mypy`` plugin to enforce strict keyword arguments."""
 
 from .plugin import plugin
 

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -1,6 +1,4 @@
-"""
-``mypy`` plugin to enforce strict keyword arguments.
-"""
+"""``mypy`` plugin to enforce strict keyword arguments."""
 
 import configparser
 import sys
@@ -22,9 +20,7 @@ def _transform_signature(
     ignore_names: list[str],
     debug: bool,
 ) -> CallableType:
-    """
-    Transform positional arguments to keyword-only arguments.
-    """
+    """Transform positional arguments to keyword-only arguments."""
     if debug:
         sys.stderr.write(f"DEBUG: mypy_strict_kwargs: {fullname}\n")
 
@@ -104,7 +100,8 @@ def _transform_signature(
 
 class KeywordOnlyPlugin(Plugin):
     """
-    A plugin that transforms positional arguments to keyword-only arguments.
+    A plugin that transforms positional arguments to keyword-only
+    arguments.
     """
 
     def __init__(self, options: Options) -> None:
@@ -157,9 +154,7 @@ class KeywordOnlyPlugin(Plugin):
         self,
         fullname: str,
     ) -> Callable[[FunctionSigContext], CallableType] | None:
-        """
-        Transform positional arguments to keyword-only arguments.
-        """
+        """Transform positional arguments to keyword-only arguments."""
         return partial(
             _transform_signature,
             fullname=fullname,
@@ -171,9 +166,7 @@ class KeywordOnlyPlugin(Plugin):
         self,
         fullname: str,
     ) -> Callable[[MethodSigContext], CallableType] | None:
-        """
-        Transform positional arguments to keyword-only arguments.
-        """
+        """Transform positional arguments to keyword-only arguments."""
         return partial(
             _transform_signature,
             fullname=fullname,
@@ -183,8 +176,6 @@ class KeywordOnlyPlugin(Plugin):
 
 
 def plugin(version: str) -> type[KeywordOnlyPlugin]:
-    """
-    Plugin entry point.
-    """
+    """Plugin entry point."""
     del version  # to satisfy vulture
     return KeywordOnlyPlugin

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for the plugin.
-"""
+"""Tests for the plugin."""

--- a/tests/test_no_config_file.py
+++ b/tests/test_no_config_file.py
@@ -1,6 +1,4 @@
-"""
-Test plugin behavior when no configuration file is provided.
-"""
+"""Test plugin behavior when no configuration file is provided."""
 
 from mypy.options import Options
 
@@ -9,7 +7,8 @@ from mypy_strict_kwargs.plugin import KeywordOnlyPlugin
 
 def test_no_config_file() -> None:
     """
-    Test that plugin provides hooks when no configuration file exists.
+    Test that plugin provides hooks when no configuration file
+    exists.
     """
     options = Options()
 


### PR DESCRIPTION
Replace docformatter with pydocstringformatter.

This follows the same pattern as https://github.com/VWS-Python/vws-python/pull/2793.

Changes:
- Replace `docformatter==1.7.7` with `pydocstringformatter==0.7.3`
- Update tool configuration in pyproject.toml
- Update ruff ignore rules (D200 → D205, D212)
- Format docstrings with new tool
- Workaround URL breaking issue by isolating URLs on their own lines where needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes docstring tooling and aligns linting rules.
> 
> - Replace `docformatter` with `pydocstringformatter` in dev deps and pre-commit; add `[tool.pydocstringformatter]` config
> - Update Ruff ignores to accommodate new docstring style (`D205`, `D212` ignored globally; add per-file `D200` ignore for `doccmd_*.py`)
> - Remove old `[tool.docformatter]` config
> - Reflow/normalize docstrings across `src/` and `tests/` (no functional code changes)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bab9ff6ae37974ddb0a44e84b6e18998f740a8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->