### PR TITLE
Remove --example-workers 0 due to mypy bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,8 +99,8 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
-          --language=console --command="shellcheck --shell=bash"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=shell --language=console
+          --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -132,8 +132,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -158,8 +157,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyright"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -187,8 +185,8 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="ty check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="ty
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -205,8 +203,8 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyrefly check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyrefly
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -221,8 +219,7 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="vulture"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -253,8 +250,7 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pylint"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -305,8 +301,7 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="interrogate"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
This removes `--example-workers 0` from the pre-commit config due to a mypy race condition bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines docs-oriented pre-commit hooks by removing `--example-workers 0` from `doccmd` commands to mitigate a mypy race condition.
> 
> - Updates `shellcheck-docs`, `mypy-docs`, `pyright-docs`, `ty-docs`, `pyrefly-docs`, `vulture-docs`, `pylint-docs`, and `interrogate-docs` to run `doccmd` without the `--example-workers` flag
> - Minor formatting/line-wrapping adjustments to affected entries; no changes to core tool behavior or non-doc hooks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f964e8e2b255f06fc76aae99c99a7ea2192732c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->