### PR TITLE
Fix: Remove --example-workers 0 only from mypy-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
 
+      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]


### PR DESCRIPTION
The previous PR incorrectly removed `--example-workers 0` from all hooks.

This PR reverts that and correctly removes it only from the `mypy-docs` hook, which is the one affected by the mypy bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns pre-commit docs checks with intended parallelism setting while exempting `mypy-docs`.
> 
> - Adds `--example-workers 0` back to `shellcheck-docs`, `pyright-docs`, `ty-docs`, `pyrefly-docs`, `vulture-docs`, `pylint-docs`, and `interrogate-docs`
> - Keeps `mypy-docs` without `--example-workers 0` and documents the mypy bug rationale
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8f4753a9ae90590be5d690f5a9a35f698858eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->