### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Test
 
 on:
@@ -16,10 +15,9 @@ permissions: {}
 
 jobs:
   build:
-
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
     "version",
@@ -299,7 +300,7 @@ pep621_dev_dependency_groups = [
 [tool.pyproject-fmt]
 indent = 4
 keep_full_version = true
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 


### PR DESCRIPTION
Add Python 3.14 to the test matrix and classifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Python 3.14 support across CI and packaging metadata.
> 
> - Extends CI matrix to include `python-version: '3.14'` on Ubuntu and Windows in `.github/workflows/ci.yml`
> - Adds `Programming Language :: Python :: 3.14` classifier and updates `tool.pyproject-fmt.max_supported_python` to `"3.14"` in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b0391a347b760e815f29c334762f49370068a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->