### PR TITLE
Add ty unused-ignore-comment rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,9 @@ typeCheckingMode = "strict"
 # used to configure a type hint.
 defineConstant = { MYPYC = false }
 
+[tool.ty.rules]
+unused-ignore-comment = "warn"
+
 [tool.pydocstringformatter]
 write = true
 split-summary-body = false


### PR DESCRIPTION
Add ty rule to warn on unused ignore comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures linting to surface unused ignore comments.
> 
> - Adds `unused-ignore-comment = "warn"` under `tool.ty.rules` in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 032847e8276e83df884092302f6962a637cbe8b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->