### PR TITLE
Add ty error-on-warning configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,8 +348,13 @@ typeCheckingMode = "strict"
 # used to configure a type hint.
 defineConstant = { MYPYC = false }
 
-[tool.ty.rules]
-unused-ignore-comment = "warn"
+[tool.ty.analysis]
+# Disable support for `type: ignore` comments
+respect-type-ignore-comments = false
+
+[tool.ty.terminal]
+# Error if ty emits any warning-level diagnostics.
+error-on-warning = true
 
 [tool.pydocstringformatter]
 write = true


### PR DESCRIPTION
Add ty configuration:
- respect-type-ignore-comments = false (for mypy compatibility)
- error-on-warning = true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures `ty` to align with strict typing and CI failure behavior.
> 
> - Adds `tool.ty.analysis` with `respect-type-ignore-comments = false` (disables `type: ignore` support)
> - Adds `tool.ty.terminal` with `error-on-warning = true` (treat warnings as errors)
> - Removes legacy `tool.ty.rules.unused-ignore-comment` configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 990604433847b5343c2464f37593f92fb62dfdf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->