### PR TITLE
Bump pyproject-fmt to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ optional-dependencies.dev = [
     "pydocstringformatter==0.7.5",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.12.1",
+    "pyproject-fmt==2.14.0",
     "pyrefly==0.51.1",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -60,42 +60,36 @@ optional-dependencies.dev = [
     "pytest-mypy-plugins==3.2.0",
     "pyyaml==6.0.3",
     "ruff==0.15.0",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "tomli==2.4.0",
     "ty==0.0.15",
     "vulture==2.14",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://mypy-strict-kwargs.readthedocs.io/en/latest/"
 urls.Source = "https://github.com/adamtheturtle/mypy-strict-kwargs"
-
 entry-points."mypy.plugins".mypy_strict_kwargs = "mypy_strict_kwargs.plugin:plugin"
 
 [tool.setuptools]
 zip-safe = false
-
-[tool.setuptools.package-data]
-mypy_strict_kwargs = [
+package-data.mypy_strict_kwargs = [
     "py.typed",
 ]
-
-[tool.setuptools.packages.find]
-where = [
+packages.find.where = [
     "src",
 ]
 
-[tool.distutils.bdist_wheel]
-universal = true
+[tool.distutils]
+bdist_wheel.universal = true
 
 [tool.setuptools_scm]
-
 # This keeps the start of the version the same as the last release.
 # This is useful for our documentation to include e.g. binary links
 # to the latest released binary.
@@ -105,32 +99,29 @@ version_scheme = "post-release"
 
 [tool.ruff]
 line-length = 79
-
 lint.select = [
     "ALL",
 ]
 lint.ignore = [
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
-    "D212",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
     # Ignore 'too-many-*' errors as they seem to get in the way more than
     # helping.
     "PLR0913",
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
+    # Ruff warns that this conflicts with the formatter.
+    "ISC001",
+    "D212",
 ]
-
 lint.per-file-ignores."doccmd_*.py" = [
+    # Allow asserts in docs.
+    "S101",
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
-    # Allow asserts in docs.
-    "S101",
 ]
-
 lint.per-file-ignores."tests/*" = [
     # use of assert in tests
     "S101",
@@ -144,21 +135,13 @@ lint.unfixable = [
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
-
-[tool.pylint.'FORMAT']
-
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
-single-line-if-stmt = false
-
-[tool.pylint.'MASTER']
-
+"FORMAT".single-line-if-stmt = false
 # Pickle collected data for later comparisons.
-persistent = true
-
+"MASTER".persistent = true
 # Use multiple processes to speed up Pylint.
-jobs = 0
-
+"MASTER".jobs = 0
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 # See https://chezsoi.org/lucas/blog/pylint-strict-base-configuration.html.
@@ -168,7 +151,7 @@ jobs = 0
 # - pylint.extensions.magic_value
 # - pylint.extensions.while_used
 # as they seemed to get in the way.
-load-plugins = [
+"MASTER".load-plugins = [
     "pylint_per_file_ignores",
     "pylint.extensions.bad_builtin",
     "pylint.extensions.comparison_placement",
@@ -186,21 +169,17 @@ load-plugins = [
     "pylint.extensions.set_membership",
     "pylint.extensions.typing",
 ]
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension = false
-extension-pkg-allow-list = [
+"MASTER".unsafe-load-any-extension = false
+"MASTER".extension-pkg-allow-list = [
     "mypy",
 ]
-
-[tool.pylint.'MESSAGES CONTROL']
-
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable = [
+"MESSAGES CONTROL".enable = [
     "bad-inline-option",
     "deprecated-pragma",
     "file-ignored",
@@ -208,7 +187,6 @@ enable = [
     "use-symbolic-message-instead",
     "useless-suppression",
 ]
-
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -218,8 +196,7 @@ enable = [
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-
-disable = [
+"MESSAGES CONTROL".disable = [
     "too-few-public-methods",
     "too-many-locals",
     "too-many-arguments",
@@ -243,28 +220,21 @@ disable = [
     # mypy does not want untyped parameters.
     "useless-type-doc",
 ]
-
 # We ignore invalid names because:
 # - We want to use generated module names, which may not be valid, but are never seen.
-per-file-ignores = [
+"MESSAGES CONTROL".per-file-ignores = [
     "doccmd_README_rst_*.py:invalid-name",
 ]
-
-[tool.pylint.'SPELLING']
-
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
-spelling-dict = 'en_US'
-
+"SPELLING".spelling-dict = "en_US"
 # A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file = 'spelling_private_dict.txt'
-
+"SPELLING".spelling-private-dict-file = "spelling_private_dict.txt"
 # Tells whether to store unknown words to indicated private dictionary in
 # --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words = 'no'
+"SPELLING".spelling-store-unknown-words = "no"
 
 [tool.check-manifest]
-
 ignore = [
     ".checkmake-config.ini",
     ".prettierrc",
@@ -302,10 +272,9 @@ indent = 4
 keep_full_version = true
 max_supported_python = "3.14"
 
-[tool.pytest.ini_options]
-
-xfail_strict = true
-log_cli = true
+[tool.pytest]
+ini_options.xfail_strict = true
+ini_options.log_cli = true
 # Do not test unrelated stubs:
 # https://github.com/typeddjango/pytest-mypy-plugins/issues/134
 #  * --mypy-only-local-stub
@@ -313,19 +282,15 @@ log_cli = true
 # Use the same process so that we can get coverage.
 #  * --mypy-same-process
 #  * The help documentation says that this "will create problems with import cache"
-addopts = "--mypy-only-local-stub --mypy-same-process"
+ini_options.addopts = "--mypy-only-local-stub --mypy-same-process"
 
-[tool.coverage.report]
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
-
-[tool.coverage.run]
-
-branch = true
+run.branch = true
 
 [tool.mypy]
-
 strict = true
 files = [ "." ]
 exclude = [ "build" ]
@@ -338,7 +303,6 @@ plugins = [
 follow_untyped_imports = true
 
 [tool.pyright]
-
 reportUnnecessaryTypeIgnoreComment = true
 enableTypeIgnoreComments = false
 typeCheckingMode = "strict"
@@ -348,13 +312,11 @@ typeCheckingMode = "strict"
 # used to configure a type hint.
 defineConstant = { MYPYC = false }
 
-[tool.ty.analysis]
+[tool.ty]
 # Disable support for `type: ignore` comments
-respect-type-ignore-comments = false
-
-[tool.ty.terminal]
+analysis.respect-type-ignore-comments = false
 # Error if ty emits any warning-level diagnostics.
-error-on-warning = true
+terminal.error-on-warning = true
 
 [tool.pydocstringformatter]
 write = true
@@ -368,7 +330,6 @@ omit-covered-files = true
 verbose = 2
 
 [tool.doc8]
-
 max_line_length = 2000
 ignore_path = [
     "./.eggs",


### PR DESCRIPTION
## Summary
- Work around tox-dev/toml-fmt#184 (double quotes in comments corrupt arrays) and tox-dev/toml-fmt#186 (single-quoted strings in arrays with comments get corrupted) by adjusting quote style
- Bump pyproject-fmt from the current version to 2.14.0
- Apply new formatting from pyproject-fmt 2.14.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a dependency bump plus config reformatting; low risk aside from potential tooling behavior changes if any keys are interpreted differently by `pylint`/`pytest`/`coverage`.
> 
> **Overview**
> Bumps the dev dependency `pyproject-fmt` to `2.14.0` and reapplies formatting updates across `pyproject.toml`.
> 
> The `pyproject.toml` config is reorganized to the newer dotted-key style for several tools (notably `setuptools`, `distutils`, `pytest`, `coverage`, `pylint`, and `ty`), plus minor quote/comment ordering tweaks intended to avoid formatter edge cases in arrays with comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25f91adeddca3629ddbd5790ef6090fc0c3bc722. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->