### PR TITLE
Update pyproject-fmt to 2.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ optional-dependencies.dev = [
     "pydocstringformatter==0.7.5",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.14.2",
+    "pyproject-fmt==2.15.2",
     "pyrefly==0.52.0",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -285,10 +285,10 @@ ini_options.log_cli = true
 ini_options.addopts = "--mypy-only-local-stub --mypy-same-process"
 
 [tool.coverage]
+run.branch = true
 report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
-run.branch = true
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Update pyproject-fmt to 2.15.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump limited to a formatting tool plus a non-functional config reordering; minimal runtime impact.
> 
> **Overview**
> Updates the dev dependency `pyproject-fmt` from `2.14.2` to `2.15.2`.
> 
> Also reorders the `coverage` config so `run.branch = true` is defined before the `report` settings (no behavioral change intended).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf9b4ce3967a153166ec7603a3f168b5449be8da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->