### PR TITLE
Matrix lint workflow by hook stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         platform: [ubuntu-latest, windows-latest]
+        hook-stage: [pre-commit, pre-push, manual]
 
     runs-on: ${{ matrix.platform }}
 
@@ -37,10 +38,8 @@ jobs:
         # Use bash to ensure the step fails if any command fails.
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
-        run: |
-          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
+        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
+          --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Refactor the lint workflow to parallelize hook stage execution by adding `hook-stage` to the build matrix. This runs all three hook stages (pre-commit, pre-push, manual) in parallel instead of sequentially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only refactor that changes CI parallelism and job count; main risk is longer/shorter CI times or stage-specific failures surfacing differently.
> 
> **Overview**
> Refactors the GitHub Actions `Lint` workflow to **matrix over `hook-stage`** (`pre-commit`, `pre-push`, `manual`), running each stage as its own parallel matrix job instead of sequential commands in a single job.
> 
> Updates the lint step to execute a single `prek run` using `${{ matrix.hook-stage }}` (keeping the existing python/platform matrix intact), increasing total job count but improving isolation and parallelism.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95ee424f536b128f2fc93b260ae4113d90a15567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->