### PR TITLE
Add pyrefly non-exhaustive match as error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,9 @@ plugins = [
 ]
 follow_untyped_imports = true
 
+[tool.pyrefly]
+errors.non-exhaustive-match = "error"
+
 [tool.pyright]
 reportUnnecessaryTypeIgnoreComment = true
 enableTypeIgnoreComments = false
@@ -353,6 +356,3 @@ ignore_names = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[tool.pyrefly]
-errors.non-exhaustive-match = "error"


### PR DESCRIPTION
Adds \ to \ in project \ files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change that tightens `pyrefly` diagnostics; risk is limited to causing new CI/type-check failures where pattern matches are incomplete.
> 
> **Overview**
> Updates `pyproject.toml` to add a `pyrefly` configuration block that **promotes `non-exhaustive-match` diagnostics to errors**, making incomplete match handling fail the type-check/lint step rather than warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0009ae144b45727042aa9e8fdcce75d23cabe505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->