### PR TITLE
Use native pytest TOML configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,8 +273,8 @@ keep_full_version = true
 max_supported_python = "3.14"
 
 [tool.pytest]
-ini_options.xfail_strict = true
-ini_options.log_cli = true
+xfail_strict = true
+log_cli = true
 # Do not test unrelated stubs:
 # https://github.com/typeddjango/pytest-mypy-plugins/issues/134
 #  * --mypy-only-local-stub
@@ -282,7 +282,7 @@ ini_options.log_cli = true
 # Use the same process so that we can get coverage.
 #  * --mypy-same-process
 #  * The help documentation says that this "will create problems with import cache"
-ini_options.addopts = "--mypy-only-local-stub --mypy-same-process"
+addopts = [ "--mypy-only-local-stub", "--mypy-same-process" ]
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary
- Remove `ini_options.` prefix from pytest configuration keys under `[tool.pytest]`
- Convert `addopts` from space-separated string to native TOML array
- Uses the native TOML configuration format supported since pytest 9.0
- See: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change limited to pytest settings; risk is mainly that older pytest versions or tooling might not recognize the new TOML keys/array format.
> 
> **Overview**
> Updates `pyproject.toml` to use pytest’s native TOML configuration keys under `[tool.pytest]` by dropping the `ini_options.` prefix and representing `addopts` as a TOML array instead of a single space-delimited string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebf39e2b9baab5bb730fd80e8840d3815a709221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->