### PR TITLE
Use tomllib from stdlib instead of tomli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ dynamic = [
 ]
 dependencies = [
     "mypy>=1.13.0",
-    # We can switch to tomllib from the standard library in Python 3.11+.
-    # Working with conditional imports in Python 3.11+ is too difficult.
-    "tomli>=1.2.2",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.10.24",
@@ -65,7 +62,6 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
-    "tomli==2.4.0",
     "ty==0.0.19",
     "vulture==2.14",
     "yamlfix==1.19.1",

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -2,11 +2,11 @@
 
 import configparser
 import sys
+import tomllib
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 
-import tomli as tomllib
 from mypy.nodes import ArgKind
 from mypy.options import Options
 from mypy.plugin import FunctionSigContext, MethodSigContext, Plugin


### PR DESCRIPTION
Now that Python 3.10 support has been dropped, we can use `tomllib` from the standard library (added in Python 3.11) instead of the third-party `tomli` dependency.

- Replace `import tomli as tomllib` with `import tomllib`
- Remove tomli from dependencies and optional-dependencies.dev

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it’s a dependency cleanup and import swap with equivalent functionality, and the project already requires Python 3.11+.
> 
> **Overview**
> Updates the plugin to `import tomllib` from the Python standard library instead of aliasing `tomli`.
> 
> Removes `tomli` from both runtime and dev dependencies in `pyproject.toml`, reducing external dependency surface now that `requires-python` is `>=3.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a11e55da382a46d7d9f2adadef0ad66d52cb4901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->