### PR TITLE
Remove unused dependabot/fetch-metadata step

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
The fetch-metadata step outputs were never used. Removing the unnecessary step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused GitHub Actions step without changing the auto-merge command or permissions; only affects workflow execution time/behavior around metadata fetching.
> 
> **Overview**
> Simplifies the `dependabot-merge.yml` workflow by removing the unused `dependabot/fetch-metadata@v2` step.
> 
> The job now only runs the `gh pr merge --auto --merge` command for Dependabot-authored PRs, reducing workflow overhead without altering merge behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b10e8fe5d273a73a0f3eddf831e1d661617822f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->