### PR TITLE
fix: use pull_request.user.login instead of github.actor for bot check

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -4,8 +4,6 @@ rules:
     disable: true
   cache-poisoning:
     disable: true
-  bot-conditions:
-    disable: true
   dependabot-cooldown:
     disable: true
   superfluous-actions:


### PR DESCRIPTION
Fixes adamtheturtle/literalizer#146

The github.actor check is unreliable - it reflects who triggered the workflow, not who opened the PR. Use github.event.pull_request.user.login instead.

Flagged by zizmor bot-conditions audit.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change that affects when the Dependabot auto-merge workflow runs; low risk beyond possibly enabling/disabling merges if the condition is wrong.
> 
> **Overview**
> Updates the Dependabot auto-merge GitHub Actions workflow to gate execution on the PR author (using `github.event.pull_request.user.login`) instead of `github.actor`, ensuring the job only runs for Dependabot-opened PRs.
> 
> Adjusts `zizmor.yml` by removing the `bot-conditions` rule override now that the workflow condition is compliant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcdb7e9aab3743e027ffe6a275190fe35045faa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->