### PR TITLE
Bump doccmd to 2026.3.26.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
-    "doccmd==2026.3.2",
+    "doccmd==2026.3.26.2",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "prek==0.3.8",


### PR DESCRIPTION
Updates the `doccmd` dev dependency to [2026.3.26.2](https://pypi.org/project/doccmd/2026.3.26.2/).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency bump with no runtime code changes; risk is limited to potential documentation tooling behavior changes in CI/dev environments.
> 
> **Overview**
> Updates the pinned `doccmd` *dev* dependency in `pyproject.toml` from `2026.3.2` to `2026.3.26.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bb859476dcfd7a62a4067b0daf5e3a2001f47b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->