### PR TITLE
chore: bump uv to 0.11.7 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.9.5
+.uv_version: &uv_version uv==0.11.7
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks


### PR DESCRIPTION
Bumps the uv pin in `.pre-commit-config.yaml` (`.uv_version` YAML anchor) to **uv 0.11.7**, matching the current [astral-sh/uv](https://github.com/astral-sh/uv) release used for pre-commit local hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `uv` version used to run pre-commit hooks, with no runtime/application logic impact.
> 
> **Overview**
> Bumps the `.uv_version` YAML anchor in `.pre-commit-config.yaml` from `uv==0.9.5` to `uv==0.11.7`, updating the `uv` version used as an `additional_dependencies` pin across local pre-commit hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d41eb152d54e8926f06af6b853ab76231f53fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->