### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,8 +143,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
-        args: [--num-workers=4]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,8 +131,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
-        args: [--num-workers=4]
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,6 +132,7 @@ repos:
         name: mypy
         stages: [pre-push]
         entry: uv run --extra=dev -m mypy
+        args: [--num-workers=4]
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -143,6 +144,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        args: [--num-workers=4]
         language: python
         types_or: [markdown, rst]
         additional_dependencies:


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to the `mypy` pre-commit hook args
- add `--num-workers=4` to the `mypy-docs` pre-commit hook args

## Test plan
- pre-commit hooks run during commit and push

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects local `pre-push` hook execution; main impact is potential mypy parallelism-related flakiness or resource usage differences on developer machines.
> 
> **Overview**
> Speeds up local type-checking by running the `mypy` and `mypy-docs` pre-commit `pre-push` hooks with `--num-workers=4`.
> 
> No code or runtime behavior changes beyond the pre-commit hook command-line arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aba5487ecb9c3e9eaf07701a3938ecdfdfcec41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->