### PR TITLE
Flag positional args to TypeVar/ParamSpec/TypeVarTuple/NewType

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Next
 ----
 
+- Flag positional arguments passed to the ``TypeVar``, ``ParamSpec``,
+  ``TypeVarTuple`` and ``NewType`` special forms.
 - Drop Python 3.10 support (requires Python >=3.11).
 
 2026.01.12

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,2 +1,8 @@
+NewType
+ParamSpec
+TypeVar
+TypeVarTuple
+kwargs
 pragma
 pyrefly
+variadic

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -283,6 +283,7 @@ class KeywordOnlyPlugin(Plugin):
 
         A module that contains no normally type checked call never
         triggers a signature hook, so its special forms are not walked.
+        See https://github.com/adamtheturtle/mypy-strict-kwargs/issues/454.
         """
         if self._modules is None:
             return

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -6,11 +6,120 @@ import tomllib
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
+from typing import cast
 
-from mypy.nodes import ArgKind
+from mypy.errorcodes import MISC
+from mypy.nodes import (
+    ArgKind,
+    AssignmentStmt,
+    Block,
+    CallExpr,
+    Expression,
+    MypyFile,
+    NewTypeExpr,
+    ParamSpecExpr,
+    RefExpr,
+    Statement,
+    TypeVarExpr,
+    TypeVarTupleExpr,
+)
 from mypy.options import Options
 from mypy.plugin import FunctionSigContext, MethodSigContext, Plugin
 from mypy.types import CallableType
+
+# ``TypeVar``, ``ParamSpec``, ``TypeVarTuple`` and ``NewType`` are processed
+# by ``mypy``'s semantic analyzer as dedicated special-form expressions
+# rather than as ordinary calls, so no call-site signature hook ever fires
+# for them.  They are instead found by walking the analyzed tree.
+#
+# Each entry maps the analyzed expression type to the name used in error
+# messages and the number of leading positional-or-keyword parameters that
+# the strict-kwargs rule requires to be passed by keyword.  For the
+# type-variable-like forms only ``name`` is positional-or-keyword (any
+# further positional arguments are ``*constraints``, which are genuinely
+# variadic).  ``NewType`` has two: ``name`` and ``tp``.
+_SPECIAL_FORMS: dict[type[Expression], tuple[str, int]] = {
+    TypeVarExpr: ("TypeVar", 1),
+    ParamSpecExpr: ("ParamSpec", 1),
+    TypeVarTupleExpr: ("TypeVarTuple", 1),
+    NewTypeExpr: ("NewType", 2),
+}
+
+# Statement attributes that hold nested statements.  ``mypy``'s visitor
+# classes are compiled traits that an interpreted plugin cannot subclass,
+# so the tree is walked by hand following these container attributes.
+_CHILD_STATEMENT_ATTRS = (
+    "body",
+    "else_body",
+    "finally_body",
+    "defs",
+    "func",
+    "impl",
+    "items",
+    "handlers",
+    "bodies",
+)
+
+
+def _iter_statements(statements: list[Statement]) -> list[Statement]:
+    """
+    Return every statement reachable from ``statements``, including
+    those inside function bodies, class bodies and compound statements.
+    """
+    collected: list[Statement] = []
+    stack = list(statements)
+    while stack:
+        statement = stack.pop()
+        collected.append(statement)
+        for attr in _CHILD_STATEMENT_ATTRS:
+            value: object = getattr(statement, attr, None)
+            children: list[object] = []
+            if isinstance(value, Block):
+                children.extend(value.body)
+            elif isinstance(value, Statement):
+                children.append(value)
+            elif isinstance(value, list):
+                children.extend(cast("list[object]", value))
+            for child in children:
+                if isinstance(child, Block):
+                    stack.extend(child.body)
+                elif isinstance(child, Statement):
+                    stack.append(child)
+    return collected
+
+
+def _find_special_form_violations(
+    tree: MypyFile,
+    *,
+    ignore_names: list[str],
+) -> list[tuple[CallExpr, str]]:
+    """
+    Return ``(call, display_name)`` pairs for special-form definitions
+    in ``tree`` that pass positional arguments where the strict-kwargs
+    rule requires keyword arguments.  ``ignore_names`` holds fully
+    qualified names to skip.
+    """
+    violations: list[tuple[CallExpr, str]] = []
+    for statement in _iter_statements(statements=tree.defs):
+        if not isinstance(statement, AssignmentStmt):
+            continue
+        call = statement.rvalue
+        if not isinstance(call, CallExpr) or call.analyzed is None:
+            continue
+        for expr_type, (display_name, prefix) in _SPECIAL_FORMS.items():
+            if not isinstance(call.analyzed, expr_type):
+                continue
+            callee = call.callee
+            if isinstance(callee, RefExpr) and callee.fullname in ignore_names:
+                break
+            uses_positional = any(
+                call.arg_kinds[index] == ArgKind.ARG_POS
+                for index in range(min(prefix, len(call.arg_kinds)))
+            )
+            if uses_positional:
+                violations.append((call, display_name))
+            break
+    return violations
 
 
 def _transform_signature(
@@ -112,6 +221,9 @@ class KeywordOnlyPlugin(Plugin):
         super().__init__(options=options)
         self._ignore_names: list[str] = []
         self._debug = False
+        self._special_form_violations: dict[
+            str, list[tuple[CallExpr, str]]
+        ] = {}
 
         if options.config_file is None:
             return
@@ -150,29 +262,90 @@ class KeywordOnlyPlugin(Plugin):
                     )
                 )
 
+    def _check_special_forms(
+        self,
+        ctx: FunctionSigContext | MethodSigContext,
+    ) -> None:
+        """
+        Flag special-form definitions that pass positional arguments.
+
+        ``TypeVar``, ``ParamSpec``, ``TypeVarTuple`` and ``NewType`` are
+        processed by ``mypy``'s semantic analyzer and never reach a
+        call-site signature hook, so the module being type checked is
+        walked to report any that pass positional arguments where
+        keyword arguments are required.
+
+        Signature hooks may run inside speculative, error-suppressed
+        type checking (for example, during operator or overload
+        resolution), so the cached violations are re-reported on every
+        invocation.  ``mypy`` drops the suppressed copies and removes
+        the remaining duplicates.
+
+        A module that contains no normally type checked call never
+        triggers a signature hook, so its special forms are not walked.
+        """
+        if self._modules is None:
+            return
+        # ``pylint`` cannot introspect the compiled ``mypy.plugin.Plugin``
+        # base class, so it does not know ``_modules`` is a mapping.
+        modules = self._modules.values()  # pylint: disable=no-member
+
+        path = ctx.api.path
+        if path not in self._special_form_violations:
+            tree: MypyFile | None = next(
+                (module for module in modules if module.path == path),
+                None,
+            )
+            if tree is not None and not tree.is_stub:
+                self._special_form_violations[path] = (
+                    _find_special_form_violations(
+                        tree=tree,
+                        ignore_names=self._ignore_names,
+                    )
+                )
+            else:
+                self._special_form_violations[path] = []
+
+        for call, display_name in self._special_form_violations[path]:
+            if self._debug:
+                sys.stderr.write(
+                    f"DEBUG: mypy_strict_kwargs: {display_name} "
+                    f"at {path}:{call.line}\n"
+                )
+            ctx.api.fail(
+                f'Too many positional arguments for "{display_name}"',
+                call,
+                code=MISC,
+            )
+
+    def _signature_hook(
+        self,
+        ctx: FunctionSigContext | MethodSigContext,
+        *,
+        fullname: str,
+    ) -> CallableType:
+        """Check special forms, then transform the call signature."""
+        self._check_special_forms(ctx=ctx)
+        return _transform_signature(
+            ctx=ctx,
+            fullname=fullname,
+            ignore_names=self._ignore_names,
+            debug=self._debug,
+        )
+
     def get_function_signature_hook(
         self,
         fullname: str,
     ) -> Callable[[FunctionSigContext], CallableType] | None:
         """Transform positional arguments to keyword-only arguments."""
-        return partial(
-            _transform_signature,
-            fullname=fullname,
-            ignore_names=self._ignore_names,
-            debug=self._debug,
-        )
+        return partial(self._signature_hook, fullname=fullname)
 
     def get_method_signature_hook(
         self,
         fullname: str,
     ) -> Callable[[MethodSigContext], CallableType] | None:
         """Transform positional arguments to keyword-only arguments."""
-        return partial(
-            _transform_signature,
-            fullname=fullname,
-            ignore_names=self._ignore_names,
-            debug=self._debug,
-        )
+        return partial(self._signature_hook, fullname=fullname)
 
 
 def plugin(version: str) -> type[KeywordOnlyPlugin]:

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -73,13 +73,11 @@ def _iter_statements(statements: list[Statement]) -> list[Statement]:
         collected.append(statement)
         for attr in _CHILD_STATEMENT_ATTRS:
             value: object = getattr(statement, attr, None)
-            children: list[object] = []
-            if isinstance(value, Block):
-                children.extend(value.body)
-            elif isinstance(value, Statement):
-                children.append(value)
-            elif isinstance(value, list):
-                children.extend(cast("list[object]", value))
+            children = (
+                cast("list[object]", value)
+                if isinstance(value, list)
+                else [value]
+            )
             for child in children:
                 if isinstance(child, Block):
                     stack.extend(child.body)

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -283,11 +283,12 @@ class KeywordOnlyPlugin(Plugin):
         triggers a signature hook, so its special forms are not walked.
         See https://github.com/adamtheturtle/mypy-strict-kwargs/issues/454.
         """
-        if self._modules is None:
-            return
+        # ``mypy`` always calls ``set_modules`` before any signature hook
+        # fires, so ``_modules`` is populated by the time this runs.
         # ``pylint`` cannot introspect the compiled ``mypy.plugin.Plugin``
         # base class, so it does not know ``_modules`` is a mapping.
-        modules = self._modules.values()  # pylint: disable=no-member
+        all_modules = cast("dict[str, MypyFile]", self._modules)
+        modules = all_modules.values()  # pylint: disable=no-member
 
         path = ctx.api.path
         if path not in self._special_form_violations:

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -160,6 +160,128 @@
     c.a
     c.a = 1
 
+# ``TypeVar``/``ParamSpec``/``TypeVarTuple``/``NewType`` are special forms
+# that ``mypy`` does not route through a call-site signature hook.  A
+# normally type checked call (``trigger``) is included so that the plugin
+# has an opportunity to walk the module and report these.
+- case: special_form_typevar
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import TypeVar
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    _T = TypeVar("_T")
+  out: |
+    main:6: error: Too many positional arguments for "TypeVar"  [misc]
+
+- case: special_form_paramspec
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import ParamSpec
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    _P = ParamSpec("_P")
+  out: |
+    main:6: error: Too many positional arguments for "ParamSpec"  [misc]
+
+- case: special_form_typevartuple
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import TypeVarTuple
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    _Ts = TypeVarTuple("_Ts")
+  out: |
+    main:6: error: Too many positional arguments for "TypeVarTuple"  [misc]
+
+- case: special_form_newtype
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import NewType
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    UserId = NewType("UserId", int)
+  out: |
+    main:6: error: Too many positional arguments for "NewType"  [misc]
+
+- case: special_form_typevar_with_bound
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import TypeVar
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    _T = TypeVar("_T", bound=int)
+  out: |
+    main:6: error: Too many positional arguments for "TypeVar"  [misc]
+
+- case: special_form_in_class_body
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import TypeVar
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+
+    class C:
+        _T = TypeVar("_T")
+  out: |
+    main:8: error: Too many positional arguments for "TypeVar"  [misc]
+
+- case: special_form_in_function
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import TypeVar
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+
+    def f() -> None:
+        _T = TypeVar("_T")
+        del _T
+  out: |
+    main:8: error: Too many positional arguments for "TypeVar"  [misc]
+
+- case: special_form_ignored
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+
+    [mypy_strict_kwargs]
+    ignore_names = typing.TypeVar
+  main: |
+    from typing import TypeVar
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    _T = TypeVar("_T")
+
 - case: ignore_name
   files:
     - path: pyproject.toml

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -282,6 +282,57 @@
     trigger(x=1)
     _T = TypeVar("_T")
 
+# A special form whose ``name`` is passed by keyword is not a
+# strict-kwargs violation (``mypy`` rejects it separately).
+- case: special_form_keyword_name_not_flagged
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import NewType
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    U = NewType(name="U", tp=int)
+  out: |
+    main:6: error: NewType(...) expects exactly two positional arguments  [misc]
+
+# A non-special-form analyzed call (here ``TypedDict``) is walked but
+# never matches, so nothing is reported.
+- case: non_special_form_analyzed_call_not_flagged
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |
+    from typing import TypedDict
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    D = TypedDict("D", {"a": int})
+
+# We disable the cache for debug tests so that --mypy-same-process
+# does not skip calling the signature hooks (which would miss the
+# debug branch for coverage).
+- case: special_form_debug
+  disable_cache: true
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+
+    [mypy_strict_kwargs]
+    debug = true
+  main: |
+    from typing import TypeVar
+
+    def trigger(*, x: int) -> None: ...
+
+    trigger(x=1)
+    _T = TypeVar("_T")
+  out: |
+    main:6: error: Too many positional arguments for "TypeVar"  [misc]
+
 - case: ignore_name
   files:
     - path: pyproject.toml


### PR DESCRIPTION
Fixes #452.

## Problem

`mypy` processes `TypeVar`, `ParamSpec`, `TypeVarTuple` and `NewType` as dedicated special-form expressions in its semantic analyzer, not as ordinary calls. `checkexpr` sees `e.analyzed` is set and skips argument checking, so **no call-site signature hook ever fires** for them — the plugin silently missed `_P = ParamSpec("_P")` and friends.

## Solution

Since no hook fires for these forms, the plugin walks the analyzed module tree from the signature hook:

- `_iter_statements` — a hand-rolled recursive statement walker (`mypy`'s `TraverserVisitor` is a compiled mypyc trait an interpreted plugin cannot subclass), reaching module, class and function bodies.
- `_find_special_form_violations` — finds assignments whose `rvalue.analyzed` is a `TypeVarExpr`/`ParamSpecExpr`/`TypeVarTupleExpr`/`NewTypeExpr` with leading positional-or-keyword arguments (`name`; also `tp` for `NewType`) passed positionally. Respects `ignore_names`.
- `_check_special_forms` — scans the current module once (caching, skipping stub files so typeshed's positional `TypeVar` idiom isn't flagged) and reports `Too many positional arguments for "..."`. Because signature hooks can run inside speculative, error-suppressed contexts, violations are re-reported on every invocation; `mypy` discards the suppressed copies and de-duplicates the rest.

Verified in non-incremental, cold incremental and warm-cache incremental modes, and for special forms nested in class/function bodies.

### Known limitation

A module containing *only* special-form definitions with no normally type-checked call never triggers a signature hook, so it isn't walked (documented in the docstring). The issue's real-world target files have other code and work.

### Note

`mypy` itself rejects the compliant rewrite — `ParamSpec(name="_P")` gives `error: ParamSpec() expects a string literal as first argument`. So this flags `ParamSpec("_P")` but `mypy`'s special-casing means there's no positional-free form it accepts for these; users would need `ignore_names`. This matches the issue's request to flag the false negative.

## Tests / checks

- 8 new `tests/test_plugin.yaml` cases (each form, `bound=`, class body, function body, `ignore_names`). 34 tests pass.
- All project tooling passes: ruff, ruff-format, mypy (self, with plugin), pyright, ty, pyrefly, pylint 10/10, vulture, interrogate 100%, deptry, doc8, sphinx-lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new AST-walking and cached diagnostics that run during signature-hook execution, which could affect performance and introduce new false positives/duplicate reporting in edge cases.
> 
> **Overview**
> The plugin now detects strict-kwargs violations in `TypeVar`, `ParamSpec`, `TypeVarTuple`, and `NewType` definitions (which `mypy` treats as special forms and previously bypassed the call-signature hooks) by walking the analyzed module AST and reporting `Too many positional arguments` with `[misc]`.
> 
> This introduces a small in-plugin statement walker, per-module caching of discovered violations, and updates both function and method signature hooks to run the special-form scan before applying the existing signature transformation; tests and changelog/spellings are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0318fdb0a6ccc17065082bf33ef4c8ce9aa06c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->