### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -319,7 +319,6 @@ repos:
         additional_dependencies:
           - *uv_version
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ ci:
     - shfmt
     - shfmt-docs
     - sphinx-lint
+    - strict-kwargs-fix
     - ty
     - ty-docs
     - pyrefly
@@ -317,6 +318,16 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
     "sphinx-lint==1.0.2",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ dynamic = [
 dependencies = [
     "mypy>=2.0.0",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://mypy-strict-kwargs.readthedocs.io/en/latest/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dynamic = [
 dependencies = [
     "mypy>=2.0.0",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
@@ -66,6 +67,7 @@ optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://mypy-strict-kwargs.readthedocs.io/en/latest/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dynamic = [
 dependencies = [
     "mypy>=2.0.0",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
     "sphinx-lint==1.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "vulture==2.16",
     "yamlfix==1.19.1",


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling, though enabling an auto-fix hook can rewrite Python callsites during commits.
> 
> **Overview**
> **Adds a new pre-commit auto-fixer for keyword-argument enforcement.** `.pre-commit-config.yaml` now runs `strict-kwargs fix` (serially) on Python files and skips it in pre-commit CI.
> 
> `pyproject.toml` adds `strict-kwargs==2026.5.18.post1` to the `dev` dependency set so the hook can run via `uv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4f16b14ed7346829c054e6078d187cdbbfa65a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->