### PR TITLE
Handle non-function property types

### DIFF
--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -167,8 +167,11 @@ def _transform_type(
         return None
 
     proper_type = get_proper_type(typ=typ)
+    if not isinstance(proper_type, FunctionLike):
+        return proper_type
+
     return _transform_function_like(
-        signature=cast("FunctionLike", proper_type),
+        signature=proper_type,
         fullname=fullname,
         ignore_names=ignore_names,
         skip_bound_argument=skip_bound_argument,

--- a/tests/test_no_config_file.py
+++ b/tests/test_no_config_file.py
@@ -1,6 +1,9 @@
 """Test plugin behavior when no configuration file is provided."""
 
+import importlib
+
 from mypy.options import Options
+from mypy.types import AnyType, TypeOfAny
 
 from mypy_strict_kwargs.plugin import KeywordOnlyPlugin
 
@@ -16,3 +19,19 @@ def test_no_config_file() -> None:
 
     assert plugin.get_function_signature_hook(fullname="test.func") is not None
     assert plugin.get_method_signature_hook(fullname="test.method") is not None
+
+
+def test_transform_type_leaves_non_function_types_unchanged() -> None:
+    """Test that non-function proper types are left unchanged."""
+    typ = AnyType(type_of_any=TypeOfAny.explicit)
+    plugin_module = importlib.import_module(name="mypy_strict_kwargs.plugin")
+    transform_type = vars(plugin_module)["_transform_type"]
+
+    transformed_type = transform_type(
+        typ=typ,
+        fullname="test.value",
+        ignore_names=[],
+        skip_bound_argument=False,
+    )
+
+    assert transformed_type is typ

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -140,6 +140,19 @@
         def method(self, a: int) -> None:
             super().method(1)
 
+- case: inherited_property
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class B:
+        @property
+        def data(self) -> bytes:
+            return b""
+
+    class C(B):
+        pass
+
 - case: callable_class_as_decorator
   mypy_config: |
     [mypy]


### PR DESCRIPTION
Fixes the base class hook crash when decorated members expose non-callable property types. The root cause was that _transform_type cast every proper type to FunctionLike before transforming it, so an Instance from a property could be treated as an overload. This now leaves non-FunctionLike proper types unchanged and adds an inherited @property regression case. Validated with pytest, ruff, ty, mypy, and the repository commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change in type transformation logic plus added regression tests; only affects cases where members (e.g., `@property`) expose non-callable types.
> 
> **Overview**
> Fixes a crash in the base-class hook by updating `_transform_type` to **only** transform `FunctionLike` signatures and to leave non-callable proper types unchanged (e.g., property/instance types).
> 
> Adds regression coverage: a unit test ensuring non-function types pass through untouched, and a `test_plugin.yaml` case for an inherited `@property`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7117d41b0a71c563e50a7cc562c388a49a095dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->