### PR TITLE
[codex] Move non-function type coverage to plugin test

### DIFF
--- a/tests/test_no_config_file.py
+++ b/tests/test_no_config_file.py
@@ -1,9 +1,6 @@
 """Test plugin behavior when no configuration file is provided."""
 
-import importlib
-
 from mypy.options import Options
-from mypy.types import AnyType, TypeOfAny
 
 from mypy_strict_kwargs.plugin import KeywordOnlyPlugin
 
@@ -19,19 +16,3 @@ def test_no_config_file() -> None:
 
     assert plugin.get_function_signature_hook(fullname="test.func") is not None
     assert plugin.get_method_signature_hook(fullname="test.method") is not None
-
-
-def test_transform_type_leaves_non_function_types_unchanged() -> None:
-    """Test that non-function proper types are left unchanged."""
-    typ = AnyType(type_of_any=TypeOfAny.explicit)
-    plugin_module = importlib.import_module(name="mypy_strict_kwargs.plugin")
-    transform_type = vars(plugin_module)["_transform_type"]
-
-    transformed_type = transform_type(
-        typ=typ,
-        fullname="test.value",
-        ignore_names=[],
-        skip_bound_argument=False,
-    )
-
-    assert transformed_type is typ

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -153,6 +153,25 @@
     class C(B):
         pass
 
+- case: inherited_no_type_check_decorated_method
+  disable_cache: true
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    from typing import no_type_check
+
+    class B:
+        @no_type_check
+        def data(self, a):
+            pass
+
+    class C(B):
+        pass
+
+    C().data(1)
+    C().data("x")
+
 - case: callable_class_as_decorator
   mypy_config: |
     [mypy]


### PR DESCRIPTION
Removes the private `_transform_type` unit test from `tests/test_no_config_file.py`.

Adds a public mypy plugin YAML case for an inherited `@no_type_check` decorated method, which exercises the non-function type path while preserving 100% plugin coverage.

Validated with `uv run --extra dev pytest tests/test_no_config_file.py tests/test_plugin.yaml --cov=mypy_strict_kwargs --cov-report=term-missing`; push hooks also passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to tests and only adjust how plugin coverage is exercised, without modifying runtime plugin logic.
> 
> **Overview**
> Shifts coverage for the plugin’s non-function type path from a direct unit test of private `_transform_type` to a new `tests/test_plugin.yaml` mypy case using an inherited `@no_type_check` method.
> 
> Simplifies `tests/test_no_config_file.py` to only verify the plugin still registers function and method signature hooks when no config file is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f8a2ae2498a1c0ea9095b5c05b69e7c8e17a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->