### PR TITLE
Ban dynamic builtins and typing.cast in lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ lint.per-file-ignores."tests/*" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
@@ -170,6 +171,17 @@ MASTER.load-plugins = [
 MASTER.unsafe-load-any-extension = false
 MASTER.extension-pkg-allow-list = [
     "mypy",
+]
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
 ]
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -6,7 +6,6 @@ import tomllib
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import cast
 
 from mypy.errorcodes import MISC
 from mypy.nodes import (
@@ -236,15 +235,11 @@ def _iter_child_nodes(node: Node) -> list[Node]:
         if not hasattr(node, attr_name):
             continue
 
-        value: object = getattr(node, attr_name)
+        value: object = object.__getattribute__(node, attr_name)
         if isinstance(value, Node):
             children.append(value)
         elif isinstance(value, (list, tuple)):
-            children.extend(
-                item
-                for item in cast("list[object] | tuple[object, ...]", value)
-                if isinstance(item, Node)
-            )
+            children.extend(item for item in value if isinstance(item, Node))
 
     return children
 

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -242,7 +242,7 @@ def _iter_child_nodes(node: Node) -> list[Node]:
         elif isinstance(value, (list, tuple)):
             children.extend(
                 item
-                for item in cast("list[object] | tuple[object, ...]", value)  # noqa: TID251
+                for item in cast("list[object] | tuple[object, ...]", value)
                 if isinstance(item, Node)
             )
 

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -6,6 +6,7 @@ import tomllib
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
+from typing import cast  # noqa: TID251
 
 from mypy.errorcodes import MISC
 from mypy.nodes import (
@@ -232,14 +233,18 @@ def _iter_child_nodes(node: Node) -> list[Node]:
     """
     children: list[Node] = []
     for attr_name in _AST_CHILD_ATTRS:
-        if not hasattr(node, attr_name):
+        if not hasattr(node, attr_name):  # pylint: disable=bad-builtin
             continue
 
-        value: object = object.__getattribute__(node, attr_name)
+        value: object = getattr(node, attr_name)  # pylint: disable=bad-builtin
         if isinstance(value, Node):
             children.append(value)
         elif isinstance(value, (list, tuple)):
-            children.extend(item for item in value if isinstance(item, Node))
+            children.extend(
+                item
+                for item in cast("list[object] | tuple[object, ...]", value)  # noqa: TID251
+                if isinstance(item, Node)
+            )
 
     return children
 


### PR DESCRIPTION
## Summary
- Add literalizer DEPRECATED_BUILTINS.bad-functions pylint config.
- Ban typing.cast via ruff where applicable.
- Fix or pylint-disable existing violations.

## Test plan
- [ ] CI lint passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to lint/static-analysis configuration plus localized suppressions to keep existing behavior compiling and linting. Primary impact is potential new lint failures in downstream code using these banned APIs.
> 
> **Overview**
> Tightens lint rules by **banning `typing.cast` via Ruff** and **flagging dynamic builtins** (`getattr`, `setattr`, `hasattr`, `filter`, `map`) via Pylint’s `DEPRECATED_BUILTINS.bad-functions`.
> 
> Updates the mypy plugin code (`plugin.py`) with targeted `# noqa`/`pylint: disable` annotations where `typing.cast`/dynamic builtins are still required during AST traversal, keeping functionality unchanged while satisfying the new lint policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbc6a0c42caabf270637c0d2a70050426e50fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->