### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ MASTER.unsafe-load-any-extension = false
 MASTER.extension-pkg-allow-list = [
     "mypy",
 ]
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that makes CI/linting stricter by failing when Pylint reports `useless-suppression`; no runtime code paths are affected.
> 
> **Overview**
> Makes Pylint runs **fail** when `useless-suppression` is emitted by adding `MAIN.fail-on = ["useless-suppression"]` in `pyproject.toml`, turning redundant `# pylint: disable=...` pragmas into a hard lint error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2c987b1362fbbec33f24796350220891b9e317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->