### PR TITLE
Cover reachable AST-traversal branches; document unreachable ones

### DIFF
--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -269,6 +269,10 @@ def _collect_call_exprs(
             _collect_call_exprs(item.callee, calls)
             for argument in item.args:
                 _collect_call_exprs(argument, calls)
+            # ``analyzed`` holds the special-form rewrite of a call (such
+            # as a ``cast()`` call).  It is populated during type
+            # checking, which runs after this base-class hook, so it is
+            # always ``None`` for the class body we traverse here.
             if item.analyzed is not None:  # pragma: no cover
                 _collect_call_exprs(item.analyzed, calls)
         case Statement() as statement:
@@ -442,6 +446,8 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
         case OpExpr(left=left, right=right) as op_expr:
             _collect_call_exprs(left, calls)
             _collect_call_exprs(right, calls)
+            # ``analyzed`` (e.g. a ``X | Y`` type expression) is only set
+            # during type checking, after this base-class hook runs.
             if op_expr.analyzed is not None:  # pragma: no cover
                 _collect_call_exprs(op_expr.analyzed, calls)
         case ComparisonExpr(operands=operands):
@@ -458,6 +464,10 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
                 _collect_call_exprs(end_index, calls)
             if stride is not None:
                 _collect_call_exprs(stride, calls)
+        # ``cast()``/``assert_type()``/``reveal_type()`` are rewritten
+        # into these nodes during type checking, after this base-class
+        # hook runs; in the class body we traverse they are still plain
+        # ``CallExpr`` nodes, so these branches are never reached here.
         case (
             CastExpr(expr=expr) | AssertTypeExpr(expr=expr)
         ):  # pragma: no cover
@@ -478,6 +488,8 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
                 if key is not None:
                     _collect_call_exprs(key, calls)
                 _collect_call_exprs(value, calls)
+        # PEP 750 template strings (``t"..."``) only parse on Python
+        # 3.14+, so this branch is not exercised by the test suite.
         case TemplateStrExpr(items=template_items):  # pragma: no cover
             for template_item in template_items:
                 match template_item:
@@ -493,6 +505,8 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
         case IndexExpr(base=base, index=index) as index_expr:
             _collect_call_exprs(base, calls)
             _collect_call_exprs(index, calls)
+            # ``analyzed`` (a type application or type alias) is only set
+            # during type checking, after this base-class hook runs.
             if index_expr.analyzed is not None:  # pragma: no cover
                 _collect_call_exprs(index_expr.analyzed, calls)
         case GeneratorExpr(
@@ -542,6 +556,9 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
             _collect_call_exprs(cond, calls)
             _collect_call_exprs(if_expr, calls)
             _collect_call_exprs(else_expr, calls)
+        # A bare ``TypeApplication`` only appears as the ``analyzed`` form
+        # of an ``IndexExpr`` produced during type checking, after this
+        # base-class hook runs, so this branch is never reached here.
         case TypeApplication(expr=expr):  # pragma: no cover
             _collect_call_exprs(expr, calls)
         case LambdaExpr():
@@ -588,7 +605,7 @@ def _collect_call_exprs_from_mapping_pattern(
     for key in keys:
         _collect_call_exprs(key, calls)
     _collect_call_exprs_from_patterns(values, calls)
-    if rest is not None:  # pragma: no cover
+    if rest is not None:
         _collect_call_exprs(rest, calls)
 
 
@@ -636,7 +653,7 @@ def _collect_call_exprs_from_pattern(
         case ValuePattern(expr=expr):
             _collect_call_exprs(expr, calls)
         case StarredPattern(capture=capture):
-            if capture is not None:  # pragma: no branch
+            if capture is not None:
                 _collect_call_exprs(capture, calls)
         case SingletonPattern():
             pass
@@ -647,7 +664,7 @@ def _collect_call_exprs_from_pattern(
                 rest=rest,
                 calls=calls,
             )
-        case ClassPattern(  # pragma: no cover
+        case ClassPattern(
             class_ref=class_ref,
             positionals=positionals,
             keyword_values=keyword_values,

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -435,7 +435,11 @@
                     one()
                 case {"k": v}:
                     one()
+                case {"j": w, **mapping_rest}:
+                    one()
                 case [a, *rest]:
+                    one()
+                case [*_]:
                     one()
                 case int():
                     one()


### PR DESCRIPTION
## Summary

Follow-up from the #472 discussion. The AST-traversal helpers in `plugin.py` carried a cluster of `# pragma: no cover` (and one `# pragma: no branch`) markers. This sorts each one into *genuinely reachable* vs *genuinely unreachable* and handles them accordingly. Coverage stays at 100%; there are **no runtime behaviour changes**.

### Reachable — now tested
Added two cases to `class_method_traversal_collects_calls`:
- `case {"j": w, **mapping_rest}:` → exercises `MappingPattern.rest`
- `case [*_]:` → exercises the `StarredPattern` "no capture" path

### Already covered — stale pragma removed
- `ClassPattern` was marked `# pragma: no cover` but is already exercised by the existing `case int():`. Pragma removed.

### Genuinely unreachable — bare pragma replaced with an explanatory comment
These only ever appear *after* type checking, which runs after `get_base_class_hook`, so the class body this plugin walks never contains them:
- the `.analyzed` slots on `CallExpr`, `OpExpr`, `IndexExpr`
- the `CastExpr` / `AssertTypeExpr` / `RevealExpr` / `TypeApplication` special-form nodes

Each now has a comment explaining *why* it's unreachable, rather than a bare suppression. The branches are kept (not deleted) so the traversal stays a faithful mirror of mypy's own traverser — dropping them would silently fall through to `case _: pass` and risk re-introducing the missed-nested-call class of bug if mypy's pass ordering ever changes.

### Documented as version-specific
- `TemplateStrExpr` (PEP 750 `t"..."` template strings) only parses on Python 3.14+, so it's documented as not exercised by the suite rather than claimed unreachable.

## How the classification was verified
Stripped all the pragmas, ran the suite under coverage, and observed exactly which branches the existing comprehensive test does and does not reach — then added the minimal cases needed to cover the reachable ones.

## Test plan
- [x] `pytest --cov-fail-under 100` — 44 passed, 100% coverage
- [x] ruff, ruff format, pylint (10.00/10), mypy, pyright, ty all clean
- [x] pre-push hooks (vulture, interrogate, yamlfix, zizmor, …) pass

> Note: no towncrier newsfragment added — this is internal (test coverage + comments), not a user-facing change. Happy to add one if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal coverage and comment-only changes to traversal helpers; no plugin behavior or public API changes.
> 
> **Overview**
> This PR tightens **test coverage and documentation** for the mypy plugin’s AST call-collection helpers in `plugin.py`, with **no intended runtime behavior change**.
> 
> It adds two `match` arms to the existing `class_method_traversal_collects_calls` fixture: `case {"j": w, **mapping_rest}` (covers `MappingPattern.rest`) and `case [*_]:` (covers `StarredPattern` when there is no capture). Stale `# pragma: no cover` on `ClassPattern` is removed because `case int():` already exercises that path.
> 
> Unreachable-at-base-class-hook branches keep their logic but gain comments explaining why `.analyzed` slots, special-form nodes (`CastExpr`, etc.), and `TypeApplication` never appear during this traversal; `TemplateStrExpr` is noted as Python 3.14+ only. A few `# pragma: no branch` suppressions on reachable pattern paths are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9d1964a58807d43439a0a3a5b7a5290b6d3117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->