### PR TITLE
Fix ty 0.0.55 structural pattern binding inference in template-string handling

### DIFF
--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -492,13 +492,13 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
         # 3.14+, so this branch is not exercised by the test suite.
         case TemplateStrExpr(items=template_items):  # pragma: no cover
             for template_item in template_items:
-                match template_item:
-                    case (expression, _, _, format_expr):
-                        _collect_call_exprs(expression, calls)
-                        if format_expr is not None:
-                            _collect_call_exprs(format_expr, calls)
-                    case Expression() as literal:
-                        _collect_call_exprs(literal, calls)
+                if isinstance(template_item, tuple):
+                    expression, _, _, format_expr = template_item
+                    _collect_call_exprs(expression, calls)
+                    if format_expr is not None:
+                        _collect_call_exprs(format_expr, calls)
+                else:
+                    _collect_call_exprs(template_item, calls)
         case SetExpr(items=items):
             for item in items:
                 _collect_call_exprs(item, calls)


### PR DESCRIPTION
ty 0.0.55 changed structural-pattern binding inference: matching a sequence pattern against `Expression | tuple[...]` now binds the unpacked elements as `object` rather than the tuple element types, producing `invalid-assignment` and `invalid-argument-type` errors in the template-string branch of `_collect_call_exprs_from_expression`. This replaces the match-based tuple destructuring with an `isinstance` check so the element types are inferred correctly. Verified clean under ty 0.0.55, mypy, pyright, and pyrefly, with all 44 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-branch refactor in a pragma no-cover PEP 750 path; no runtime or security impact for supported Python versions.
> 
> **Overview**
> Updates **`TemplateStrExpr`** handling in `_collect_call_exprs_from_expression` so nested calls are still collected when type-checking with **ty 0.0.55**.
> 
> The inner loop no longer uses a **structural `match`** on each `template_item` (tuple vs `Expression`). It now branches on **`isinstance(template_item, tuple)`**, unpacks the four tuple slots for expression/format parts, and otherwise treats the item as a literal expression—same traversal behavior, different inference path for static analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421172c164cf3ff4c420f96af22d7b152d237a23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->