### PR TITLE
Fix mypy 2.2 diagnostic expectations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ With this plugin, ``mypy`` will only accept the form where keyword arguments are
 
 
    add(a=1, b=2)  # With this plugin, ``mypy`` will only accept this form
-   add(1, 2)  # type: ignore[misc]
-   add(1, b=2)  # type: ignore[misc]
+   add(1, 2)  # type: ignore[call-arg]
+   add(1, b=2)  # type: ignore[call-arg]
 
 Why?
 ----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ optional-dependencies.dev = [
     "doc8==2.0.0",
     "doccmd==2026.5.25",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==2.1.0",
+    "mypy[faster-cache]==2.2.0",
     "prek==0.4.8",
     "pydocstringformatter==1.0.0",
     "pylint[spelling]==4.0.6",

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -15,7 +15,7 @@
     def func(a: int) -> None: ...
     func(1)
   out: |
-    main:2: error: Too many positional arguments for "func"  [misc]
+    main:2: error: Too many positional arguments for "func"  [call-arg]
 
 - case: positional_optional
   mypy_config: |
@@ -26,7 +26,7 @@
     func(1)
     func()
   out: |
-    main:2: error: Too many positional arguments for "func"  [misc]
+    main:2: error: Too many positional arguments for "func"  [call-arg]
 
 - case: keyword_only
   mypy_config: |
@@ -86,7 +86,7 @@
     def func(a: int, **kwargs: str) -> None: ...
     func(1)
   out: |
-    main:2: error: Too many positional arguments for "func"  [misc]
+    main:2: error: Too many positional arguments for "func"  [call-arg]
 
 - case: var_positional_followed_by_keyword
   mypy_config: |
@@ -109,7 +109,7 @@
     c = C()
     c.method(1)
   out: |-
-    main:7: error: Too many positional arguments for "method" of "C"  [misc]
+    main:7: error: Too many positional arguments for "method" of "C"  [call-arg]
 
 - case: super_method
   mypy_config: |
@@ -599,7 +599,7 @@
     c(func=lambda: None, a=1)
     c(lambda: None, a=1)
   out: |-
-    main:7: error: Too many positional arguments for "__call__" of "C"  [misc]
+    main:7: error: Too many positional arguments for "__call__" of "C"  [call-arg]
 
 - case: descriptor
   mypy_config: |
@@ -638,7 +638,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 # We disable the cache for debug tests so that --mypy-same-process
 # does not skip calling the signature hooks (which would miss the
@@ -663,7 +663,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 - case: ignore_name_ini
   mypy_config: |
@@ -681,7 +681,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 # We disable the cache for debug tests so that --mypy-same-process
 # does not skip calling the signature hooks (which would miss the
@@ -704,7 +704,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 - case: ignore_name_ini_no_spaces
   mypy_config: |
@@ -722,7 +722,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 # Test when no mypy_strict_kwargs section exists - plugin should work with defaults
 - case: no_plugin_section_ini
@@ -733,7 +733,7 @@
     def func(a: int) -> None: ...
     func(1)
   out: |-
-    main:2: error: Too many positional arguments for "func"  [misc]
+    main:2: error: Too many positional arguments for "func"  [call-arg]
 
 # Test when ignore_names is empty
 - case: empty_ignore_names_ini
@@ -747,7 +747,7 @@
     def func(a: int) -> None: ...
     func(1)
   out: |-
-    main:2: error: Too many positional arguments for "func"  [misc]
+    main:2: error: Too many positional arguments for "func"  [call-arg]
 
 - case: ignore_name_dot_mypy_ini
   files:
@@ -767,7 +767,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 - case: ignore_name_setup_cfg
   files:
@@ -787,7 +787,7 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]
 
 # We disable the cache for debug tests so that --mypy-same-process
 # does not skip calling the signature hooks (which would miss the
@@ -812,4 +812,4 @@
 
     str(1)
   out: |-
-    main:5: error: Too many positional arguments for "not_ignored"  [misc]
+    main:5: error: Too many positional arguments for "not_ignored"  [call-arg]


### PR DESCRIPTION
Updates the development mypy pin to 2.2.0 and adjusts expected diagnostics to match mypy’s new `call-arg` error code for transformed positional-argument calls.

The README examples now use `type: ignore[call-arg]`, so the generated docs mypy check no longer reports unused `misc` ignores.

The plugin behavior is unchanged; this fixes CI after the dependency bump changed mypy’s emitted error code.

Validated with `UV_PYTHON=3.11 uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose` and `uv run --extra=dev --python=3.13 pytest -q --cov-fail-under 100 --cov=src/ --cov=tests/ .`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test expectation updates plus a dev-only mypy version bump; runtime plugin code is untouched.
> 
> **Overview**
> Bumps the **dev** mypy pin from **2.1.0** to **2.2.0** and updates docs and tests so expected diagnostics match mypy’s new **`call-arg`** code for “too many positional arguments” on calls affected by the plugin’s signature transforms.
> 
> README examples now use `type: ignore[call-arg]` instead of `type: ignore[misc]`, avoiding unused-ignore failures when doc snippets are type-checked. **`tests/test_plugin.yaml`** expected outputs are updated the same way for the affected cases; **plugin behavior is unchanged**—only CI expectations and the README track mypy 2.2’s reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa39970697c52d3774ef3459d8bfc29c4a33254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->