### PR TITLE
Fix super calls with variadic positional arguments

### DIFF
--- a/newsfragments/549.change
+++ b/newsfragments/549.change
@@ -1,0 +1,2 @@
+Fix false positives for ``super()`` calls whose remaining positional
+arguments are consumed by ``*args``.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -222,7 +222,11 @@ def _call_disallows_positional_argument(
         if formal_arg_index >= len(transformed.arg_kinds):
             return False
 
-        if transformed.arg_kinds[formal_arg_index] in {
+        formal_arg_kind = transformed.arg_kinds[formal_arg_index]
+        if formal_arg_kind == ArgKind.ARG_STAR:
+            return False
+
+        if formal_arg_kind in {
             ArgKind.ARG_NAMED,
             ArgKind.ARG_NAMED_OPT,
         }:

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -202,6 +202,23 @@
         def method(self, a: int) -> None:
             super().method(1)
 
+- case: super_method_var_positional_followed_by_keyword
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class B:
+        def method(
+            self,
+            first: int,
+            *rest: int,
+            option: int = 0,
+        ) -> None: ...
+
+    class C(B):
+        def call(self) -> None:
+            super().method(1, 2, 3)
+
 - case: super_method_too_many_arguments
   mypy_config: |
     [mypy]


### PR DESCRIPTION
Closes #549.

## What changed

- Stop the manual super() argument mapper when it reaches an *args formal.
- Add a regression test for positional arguments followed by a keyword-only parameter.
- Add a changelog fragment.

## Why

Variadic positional parameters consume all remaining positional arguments. Advancing the mapper beyond *args incorrectly treated later arguments as targeting keyword-only parameters and produced false positives.

## Validation

- uv run --extra=dev pytest -q (45 passed)
- uv run --extra=dev prek run --all-files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to super()-call validation logic with a regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes incorrect **"too many positional arguments"** errors on `super().method(...)` when the parent signature includes `*args` followed by keyword-only parameters.
> 
> In `_call_disallows_positional_argument`, the mapper now **stops** when the matched formal is `ArgKind.ARG_STAR`, treating remaining positional actuals as consumed by `*args` instead of mapping them to later keyword-only formals.
> 
> Adds regression coverage for `super().method(1, 2, 3)` on `(first, *rest, option=0)` and a newsfragment for #549.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f26ff8e4d965f3f5a8000a9897bf96cb444954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->