### PR TITLE
Respect explicit super MRO position

### DIFF
--- a/newsfragments/550.change
+++ b/newsfragments/550.change
@@ -1,0 +1,2 @@
+Respect the explicit starting type when checking two-argument ``super()``
+calls.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -200,29 +200,30 @@ def _super_method_mro(
     ctx: ClassDefContext,
     expr: CallExpr,
 ) -> list[TypeInfo]:
-    """Return the MRO entries searched by the ``super()`` call."""
+    """Return method-resolution entries searched by ``super()``."""
     callee = expr.callee
     if not isinstance(callee, SuperExpr) or not callee.call.args:
         return ctx.cls.info.mro[1:]
 
     explicit_super_type = callee.call.args[0]
-    if not isinstance(explicit_super_type, (NameExpr, MemberExpr)):
+    if not isinstance(  # pragma: no cover
+        explicit_super_type,
+        (NameExpr, MemberExpr),
+    ):
         return ctx.cls.info.mro[1:]
 
-    explicit_super_info = explicit_super_type.node
-    if not isinstance(explicit_super_info, TypeInfo):
-        symbol = ctx.api.lookup_qualified(
-            name=explicit_super_type.name,
-            ctx=explicit_super_type,
-            suppress_errors=True,
-        )
-        explicit_super_info = None if symbol is None else symbol.node
-    if not isinstance(explicit_super_info, TypeInfo):
+    symbol = ctx.api.lookup_qualified(
+        name=explicit_super_type.name,
+        ctx=explicit_super_type,
+        suppress_errors=True,
+    )
+    explicit_super_info = None if symbol is None else symbol.node
+    if not isinstance(explicit_super_info, TypeInfo):  # pragma: no cover
         return ctx.cls.info.mro[1:]
 
     try:
         super_type_index = ctx.cls.info.mro.index(explicit_super_info)
-    except ValueError:
+    except ValueError:  # pragma: no cover
         return ctx.cls.info.mro[1:]
     return ctx.cls.info.mro[super_type_index + 1 :]
 

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -206,7 +206,7 @@ def _super_method_mro(
         return ctx.cls.info.mro[1:]
 
     explicit_super_type = callee.call.args[0]
-    if not isinstance(  # pragma: no cover
+    if not isinstance(
         explicit_super_type,
         (NameExpr, MemberExpr),
     ):
@@ -218,12 +218,12 @@ def _super_method_mro(
         suppress_errors=True,
     )
     explicit_super_info = None if symbol is None else symbol.node
-    if not isinstance(explicit_super_info, TypeInfo):  # pragma: no cover
+    if not isinstance(explicit_super_info, TypeInfo):
         return ctx.cls.info.mro[1:]
 
     try:
         super_type_index = ctx.cls.info.mro.index(explicit_super_info)
-    except ValueError:  # pragma: no cover
+    except ValueError:
         return ctx.cls.info.mro[1:]
     return ctx.cls.info.mro[super_type_index + 1 :]
 

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -40,6 +40,7 @@ from mypy.nodes import (
     ListExpr,
     MatchStmt,
     MemberExpr,
+    NameExpr,
     OperatorAssignmentStmt,
     OpExpr,
     OverloadedFuncDef,
@@ -56,6 +57,7 @@ from mypy.nodes import (
     TryStmt,
     TupleExpr,
     TypeApplication,
+    TypeInfo,
     UnaryExpr,
     WhileStmt,
     WithStmt,
@@ -191,6 +193,38 @@ def _super_method_name(expr: CallExpr) -> str | None:
             return name
         case _:
             return None
+
+
+def _super_method_mro(
+    *,
+    ctx: ClassDefContext,
+    expr: CallExpr,
+) -> list[TypeInfo]:
+    """Return the MRO entries searched by the ``super()`` call."""
+    callee = expr.callee
+    if not isinstance(callee, SuperExpr) or not callee.call.args:
+        return ctx.cls.info.mro[1:]
+
+    explicit_super_type = callee.call.args[0]
+    if not isinstance(explicit_super_type, (NameExpr, MemberExpr)):
+        return ctx.cls.info.mro[1:]
+
+    explicit_super_info = explicit_super_type.node
+    if not isinstance(explicit_super_info, TypeInfo):
+        symbol = ctx.api.lookup_qualified(
+            name=explicit_super_type.name,
+            ctx=explicit_super_type,
+            suppress_errors=True,
+        )
+        explicit_super_info = None if symbol is None else symbol.node
+    if not isinstance(explicit_super_info, TypeInfo):
+        return ctx.cls.info.mro[1:]
+
+    try:
+        super_type_index = ctx.cls.info.mro.index(explicit_super_info)
+    except ValueError:
+        return ctx.cls.info.mro[1:]
+    return ctx.cls.info.mro[super_type_index + 1 :]
 
 
 def _call_disallows_positional_argument(
@@ -694,7 +728,7 @@ def _check_super_method_call(
     ignore_names: list[str],
 ) -> None:
     """Check one ``super()`` method call expression."""
-    for info in ctx.cls.info.mro[1:]:
+    for info in _super_method_mro(ctx=ctx, expr=expr):
         symbol = info.names.get(method_name)
         if symbol is None:
             continue

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -193,6 +193,61 @@
         def call(self) -> None:
             super(B, self).method(1)
 
+# Fall back to zero-argument super() MRO when the first argument is not a
+# simple name or attribute (e.g. an index expression).
+- case: super_method_explicit_super_non_name
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class B:
+        def method(self, a: int) -> None: ...
+
+    class C(B):
+        def method(self, a: int) -> None:
+            classes = (B,)
+            super(classes[0], self).method(1)
+  out: |-
+    main:7: error: Too many positional arguments for "method" of "B"  [misc]
+    main:7: error: "method" undefined in superclass  [misc]
+
+# Fall back when the first argument name does not resolve to a type.
+- case: super_method_explicit_super_non_type
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    x = 1
+
+    class B:
+        def method(self, a: int) -> None: ...
+
+    class C(B):
+        def method(self, a: int) -> None:
+            super(x, self).method(1)
+  out: |-
+    main:8: error: Too many positional arguments for "method" of "B"  [misc]
+    main:8: error: Argument 1 for "super" must be a type object; got a non-type instance  [arg-type]
+
+# Fall back when the explicit type is not in the current class MRO.
+- case: super_method_explicit_super_not_in_mro
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Unrelated:
+        pass
+
+    class B:
+        def method(self, a: int) -> None: ...
+
+    class C(B):
+        def method(self, a: int) -> None:
+            super(Unrelated, self).method(1)
+  out: |-
+    main:9: error: Too many positional arguments for "method" of "B"  [misc]
+    main:9: error: Argument 2 for "super" not an instance of argument 1  [misc]
+
 - case: super_method_keyword_argument
   mypy_config: |
     [mypy]

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -178,6 +178,21 @@
   out: |-
     main:6: error: Too many positional arguments for "method" of "B"  [misc]
 
+- case: super_method_explicit_super_from_base
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class A:
+        def method(self, value: int, /) -> None: ...
+
+    class B(A):
+        def method(self, value: int) -> None: ...
+
+    class C(B):
+        def call(self) -> None:
+            super(B, self).method(1)
+
 - case: super_method_keyword_argument
   mypy_config: |
     [mypy]


### PR DESCRIPTION
Closes #550.

## What changed

- Resolve the explicit type passed to super(type, obj) during semantic analysis.
- Start method lookup after that exact type in the current class MRO.
- Add a regression test and changelog fragment.

## Why

Two-argument super calls start lookup after their supplied type, not unconditionally after the current class.

## Validation

- uv run --extra=dev pytest -q (45 passed)
- repository pre-commit and pre-push checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to super() MRO selection in the mypy plugin with fallbacks matching prior behavior when the explicit type cannot be resolved.
> 
> **Overview**
> Fixes **strict keyword-argument checking** for `super().method(...)` when callers use **two-argument** `super(type, obj)`.
> 
> The plugin used to walk **`mro[1:]`** from the enclosing class for every `super()` method call, so `super(B, self).method(...)` could be validated against the wrong base (e.g. `B` instead of the types **after** `B`). It now adds **`_super_method_mro`**, which reads the explicit type from `SuperExpr.call.args[0]`, resolves it to a `TypeInfo`, and searches **`mro[index + 1:]`** when that type is a simple name/attribute in the MRO; otherwise it keeps the previous **`mro[1:]`** fallback.
> 
> Regression tests cover starting lookup from an intermediate base, plus fallback paths for non-name first arguments, non-types, and types outside the MRO. A changelog fragment documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3fedcccba095d73de6641ec2ef4ad33fa3aa0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->