### PR TITLE
Use nested class MRO for super checks

### DIFF
--- a/newsfragments/551.change
+++ b/newsfragments/551.change
@@ -1,0 +1,2 @@
+Check nested-class ``super()`` calls against the nested class's MRO instead
+of the enclosing class's MRO.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -465,7 +465,6 @@ def _collect_call_exprs_from_statement(  # noqa: C901, PLR0912, PLR0915  # pylin
             base_type_exprs=base_type_exprs,
             metaclass=metaclass,
             keywords=keywords,
-            defs=defs,
         ):
             for decorator in decorators:
                 _collect_call_exprs(decorator, calls)
@@ -475,7 +474,6 @@ def _collect_call_exprs_from_statement(  # noqa: C901, PLR0912, PLR0915  # pylin
                 _collect_call_exprs(metaclass, calls)
             for keyword_expression in keywords.values():
                 _collect_call_exprs(keyword_expression, calls)
-            _collect_call_exprs(defs, calls)
         case _:
             pass
 

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -466,6 +466,22 @@
     main:7: error: Definition of "method" in base class "B" is incompatible with definition in base class "A"  [misc]
     main:9: error: "int" not callable  [operator]
 
+- case: nested_class_super_uses_nested_class_mro
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class PositionalOnlyBase:
+        def method(self, value: int, /) -> None: ...
+
+    class KeywordBase:
+        def method(self, value: int) -> None: ...
+
+    class Outer(KeywordBase):
+        class Inner(PositionalOnlyBase):
+            def call(self) -> None:
+                super().method(1)
+
 - case: class_method_traversal_collects_calls
   disable_cache: true
   mypy_config: |


### PR DESCRIPTION
Closes #551.

## What changed

- Stop recursively traversing nested class bodies from an enclosing class hook.
- Continue checking class header expressions in their enclosing context.
- Add a nested-class regression test and changelog fragment.

## Why

Each nested class receives its own base-class hook. Traversing its body from the outer hook checked super calls against the unrelated outer MRO.

## Validation

- uv run --extra=dev pytest -q (45 passed)
- repository pre-commit and pre-push checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to AST traversal for class definitions in the mypy plugin, with a regression test and no auth or runtime behavior changes.
> 
> **Overview**
> Fixes incorrect **strict keyword-argument** diagnostics for `super().method(...)` inside **nested classes**.
> 
> The plugin’s class-body call collector no longer walks a nested class’s `defs` when processing an enclosing `ClassDef`. Header expressions (bases, decorators, metaclass, keywords) are still collected in the outer context; each nested class is analyzed separately via its own base-class hook, so `super()` is checked against **that class’s MRO** instead of the enclosing class’s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748b8767136b9588c6072546948b53c86262f0f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->