### PR TITLE
Stop super lookup at resolved member

### DIFF
--- a/newsfragments/552.change
+++ b/newsfragments/552.change
@@ -1,0 +1,2 @@
+Stop ``super()`` method lookup at the first MRO entry defining the member,
+matching Python's runtime attribute lookup.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -710,7 +710,7 @@ def _check_super_method_call(
                 typ = node.func.type
                 skip_bound_argument = node.func.has_self_or_cls_argument
             case _:
-                continue
+                return
 
         if fullname in ignore_names:
             return
@@ -734,6 +734,7 @@ def _check_super_method_call(
                 code=MISC,
             )
             return
+        return
 
 
 def _check_super_method_calls(

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -319,7 +319,7 @@
         def method(self, a: int) -> None:
             super().method(1)
 
-- case: super_method_continues_past_positional_only_base
+- case: super_method_stops_at_positional_only_base
   mypy_config: |
     [mypy]
     plugins = mypy_strict_kwargs
@@ -333,8 +333,24 @@
     class C(B, A):
         def method(self, a: int) -> None:
             super().method(1)
+
+- case: super_method_stops_at_non_callable_base_member
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class A:
+        def method(self, a: int) -> None: ...
+
+    class B:
+        method = 1
+
+    class C(B, A):
+        def call(self) -> None:
+            super().method(1)
   out: |-
-    main:9: error: Too many positional arguments for "method" of "A"  [misc]
+    main:7: error: Definition of "method" in base class "B" is incompatible with definition in base class "A"  [misc]
+    main:9: error: "int" not callable  [operator]
 
 - case: class_method_traversal_collects_calls
   disable_cache: true


### PR DESCRIPTION
Closes #552.

## What changed

- Stop the manual super method scan after the first MRO entry defining the member.
- Stop there for both callable and non-callable members.
- Update the former false-positive test and add a non-callable regression case.
- Add a changelog fragment.

## Why

Python runtime attribute lookup does not continue to later MRO entries once a member is found.

## Validation

- uv run --extra=dev pytest -q (45 passed)
- repository pre-commit and pre-push checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to super()-call validation in the plugin; behavior matches runtime lookup with updated tests.
> 
> **Overview**
> Aligns **mypy_strict_kwargs** `super().method(...)` checks with Python: once an MRO base **defines** the name, the plugin stops there instead of scanning later bases.
> 
> For a **non-callable** member (e.g. `method = 1`), the handler now **returns** immediately rather than **continuing** the MRO walk. After resolving a **callable** method, it also **returns** after the positional-argument check, so a later base cannot trigger a spurious “too many positional arguments” error.
> 
> Tests rename/update the diamond `C(B, A)` case (positional-only `B` no longer reports against `A`) and add a regression where `B` shadows `A` with a non-callable `method`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28239fe11d016455fa630ca9d64227fad35e8934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->