### PR TITLE
Check fixed tuple unpacking in super calls

### DIFF
--- a/newsfragments/553.change
+++ b/newsfragments/553.change
@@ -1,0 +1,2 @@
+Check positional arguments supplied to ``super()`` methods by unpacking
+fixed-length tuples.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -104,6 +104,10 @@ class _CollectedCalls(list[CallExpr]):
         """Initialize an empty collection."""
         super().__init__()
         self.fixed_tuple_lengths: dict[CallExpr, dict[str, int]] = {}
+        # Parameter names bound by scopes already attached to each call, so
+        # that an inner scope's name shadows an outer scope's parameter of
+        # the same name even when the inner binding is not a fixed tuple.
+        self.bound_parameter_names: dict[CallExpr, set[str]] = {}
 
 
 def _preserved_positional_argument_count(
@@ -534,10 +538,18 @@ def _collect_call_exprs_from_func_item(
         is not None
     }
     for call in calls[first_body_call_index:]:
-        calls.fixed_tuple_lengths.setdefault(
-            call,
-            fixed_tuple_lengths,
-        )
+        # Inner scopes are collected first, so their parameters shadow this
+        # enclosing scope's parameters of the same name -- even when the
+        # inner binding is not a fixed tuple.
+        bound_names = calls.bound_parameter_names.setdefault(call, set())
+        lengths = calls.fixed_tuple_lengths.setdefault(call, {})
+        for argument in func_item.arguments:
+            name = argument.variable.name
+            if name in bound_names:
+                continue
+            bound_names.add(name)
+            if name in fixed_tuple_lengths:
+                lengths[name] = fixed_tuple_lengths[name]
 
 
 def _fixed_tuple_annotation_length(*, annotation: Type | None) -> int | None:

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -351,7 +351,7 @@ def _super_call_disallows_positional_argument(
 
 def _collect_call_exprs(
     item: _CallExprContainer,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
     /,
 ) -> None:
     """Collect call expressions from a syntax-tree node or expression."""
@@ -377,7 +377,7 @@ def _collect_call_exprs(
 
 def _collect_call_exprs_from_statement(  # noqa: C901, PLR0912, PLR0915  # pylint: disable=too-complex,too-many-branches,too-many-statements
     statement: Statement,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
     /,
 ) -> None:
     """Collect call expressions from a statement."""
@@ -513,7 +513,7 @@ def _collect_call_exprs_from_statement(  # noqa: C901, PLR0912, PLR0915  # pylin
 
 def _collect_call_exprs_from_func_item(
     func_item: FuncItem,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
     /,
 ) -> None:
     """Collect call expressions from a function or lambda."""
@@ -523,22 +523,21 @@ def _collect_call_exprs_from_func_item(
     first_body_call_index = len(calls)
     _collect_call_exprs(func_item.body, calls)
 
-    if isinstance(calls, _CollectedCalls):
-        fixed_tuple_lengths = {
-            argument.variable.name: fixed_tuple_length
-            for argument in func_item.arguments
-            if (
-                fixed_tuple_length := _fixed_tuple_annotation_length(
-                    annotation=argument.type_annotation,
-                )
+    fixed_tuple_lengths = {
+        argument.variable.name: fixed_tuple_length
+        for argument in func_item.arguments
+        if (
+            fixed_tuple_length := _fixed_tuple_annotation_length(
+                annotation=argument.type_annotation,
             )
-            is not None
-        }
-        for call in calls[first_body_call_index:]:
-            calls.fixed_tuple_lengths.setdefault(
-                call,
-                fixed_tuple_lengths,
-            )
+        )
+        is not None
+    }
+    for call in calls[first_body_call_index:]:
+        calls.fixed_tuple_lengths.setdefault(
+            call,
+            fixed_tuple_lengths,
+        )
 
 
 def _fixed_tuple_annotation_length(*, annotation: Type | None) -> int | None:
@@ -557,7 +556,7 @@ def _fixed_tuple_annotation_length(*, annotation: Type | None) -> int | None:
 
 def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pylint: disable=too-complex,too-many-branches,too-many-statements
     expression: Expression,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
     /,
 ) -> None:
     """Collect call expressions from an expression."""
@@ -697,7 +696,7 @@ def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pyli
 
 def _collect_call_exprs_from_patterns(
     patterns: list[Pattern],
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
     /,
 ) -> None:
     """Collect call expressions from match patterns."""
@@ -709,7 +708,7 @@ def _collect_call_exprs_from_as_pattern(
     *,
     inner_pattern: Pattern | None,
     name: Expression | None,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
 ) -> None:
     """Collect call expressions from an as pattern."""
     if inner_pattern is not None:
@@ -723,7 +722,7 @@ def _collect_call_exprs_from_mapping_pattern(
     keys: list[Expression],
     values: list[Pattern],
     rest: Expression | None,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
 ) -> None:
     """Collect call expressions from a mapping pattern."""
     for key in keys:
@@ -738,7 +737,7 @@ def _collect_call_exprs_from_class_pattern(
     class_ref: Expression,
     positionals: list[Pattern],
     keyword_values: list[Pattern],
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
 ) -> None:
     """Collect call expressions from a class pattern."""
     _collect_call_exprs(class_ref, calls)
@@ -748,7 +747,7 @@ def _collect_call_exprs_from_class_pattern(
 
 def _collect_call_exprs_from_pattern(
     pattern: Pattern,
-    calls: list[CallExpr],
+    calls: _CollectedCalls,
     /,
 ) -> None:
     """Collect call expressions from a match pattern."""

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -933,7 +933,12 @@ def _check_super_method_calls(
     *,
     ignore_names: list[str],
 ) -> None:
-    """Check ``super()`` method calls in a class body."""
+    """Check ``super()`` method calls in a class body.
+
+    Needed because ``mypy`` does not run method signature hooks for
+    ``super().method(...)``
+    (https://github.com/python/mypy/issues/21744).
+    """
     calls = _iter_call_exprs(ctx.cls.defs)
     for expr in calls:
         method_name = _super_method_name(expr=expr)
@@ -1038,6 +1043,11 @@ class KeywordOnlyPlugin(Plugin):
     ) -> Callable[[ClassDefContext], None] | None:
         """Check ``super()`` method calls without mutating base
         classes.
+
+        ``get_method_signature_hook`` is not invoked for
+        ``super().method(...)``
+        (https://github.com/python/mypy/issues/21744), so this hook
+        walks class bodies and checks those call sites manually.
         """
         del fullname
         return partial(

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -86,9 +86,24 @@ from mypy.plugin import (
     Plugin,
     ReportConfigContext,
 )
-from mypy.types import CallableType, FunctionLike
+from mypy.types import (
+    CallableType,
+    EllipsisType,
+    FunctionLike,
+    Type,
+    UnboundType,
+)
 
 _CallExprContainer = Expression | Statement
+
+
+class _CollectedCalls(list[CallExpr]):
+    """Call expressions and fixed tuple lengths visible to each call."""
+
+    def __init__(self) -> None:
+        """Initialize an empty collection."""
+        super().__init__()
+        self.fixed_tuple_lengths: dict[CallExpr, dict[str, int]] = {}
 
 
 def _preserved_positional_argument_count(
@@ -256,6 +271,7 @@ def _call_disallows_positional_argument(
     fullname: str,
     ignore_names: list[str],
     skip_bound_argument: bool,
+    fixed_tuple_lengths: dict[str, int],
 ) -> bool:
     """Return whether a call passes a transformed argument by position."""
     transformed = _transform_callable_type(
@@ -266,28 +282,41 @@ def _call_disallows_positional_argument(
         preserved_positional_argument_count=0,
     )
 
-    positional_argument_index = 0
-    for actual_arg_kind in call.arg_kinds:
-        if actual_arg_kind != ArgKind.ARG_POS:
+    formal_arg_index = 1 if skip_bound_argument else 0
+    for actual_arg, actual_arg_kind in zip(
+        call.args,
+        call.arg_kinds,
+        strict=True,
+    ):
+        if actual_arg_kind == ArgKind.ARG_POS:
+            positional_argument_count = 1
+        elif actual_arg_kind == ArgKind.ARG_STAR:
+            if isinstance(actual_arg, TupleExpr):
+                positional_argument_count = len(actual_arg.items)
+            elif isinstance(actual_arg, NameExpr):
+                positional_argument_count = fixed_tuple_lengths.get(
+                    actual_arg.name,
+                    0,
+                )
+            else:
+                positional_argument_count = 0
+        else:
             continue
 
-        formal_arg_index = positional_argument_index
-        if skip_bound_argument:
+        for _ in range(positional_argument_count):
+            if formal_arg_index >= len(transformed.arg_kinds):
+                return False
+
+            formal_arg_kind = transformed.arg_kinds[formal_arg_index]
+            if formal_arg_kind == ArgKind.ARG_STAR:
+                return False
             formal_arg_index += 1
-        positional_argument_index += 1
 
-        if formal_arg_index >= len(transformed.arg_kinds):
-            return False
-
-        formal_arg_kind = transformed.arg_kinds[formal_arg_index]
-        if formal_arg_kind == ArgKind.ARG_STAR:
-            return False
-
-        if formal_arg_kind in {
-            ArgKind.ARG_NAMED,
-            ArgKind.ARG_NAMED_OPT,
-        }:
-            return True
+            if formal_arg_kind in {
+                ArgKind.ARG_NAMED,
+                ArgKind.ARG_NAMED_OPT,
+            }:
+                return True
 
     return False
 
@@ -299,6 +328,7 @@ def _super_call_disallows_positional_argument(
     fullname: str,
     ignore_names: list[str],
     skip_bound_argument: bool,
+    fixed_tuple_lengths: dict[str, int],
 ) -> bool:
     """Return whether every overload rejects positional super
     arguments.
@@ -313,6 +343,7 @@ def _super_call_disallows_positional_argument(
             fullname=fullname,
             ignore_names=ignore_names,
             skip_bound_argument=skip_bound_argument,
+            fixed_tuple_lengths=fixed_tuple_lengths,
         )
         for callable_item in callable_items
     )
@@ -489,7 +520,39 @@ def _collect_call_exprs_from_func_item(
     for argument in func_item.arguments:
         if argument.initializer is not None:
             _collect_call_exprs(argument.initializer, calls)
+    first_body_call_index = len(calls)
     _collect_call_exprs(func_item.body, calls)
+
+    if isinstance(calls, _CollectedCalls):
+        fixed_tuple_lengths = {
+            argument.variable.name: fixed_tuple_length
+            for argument in func_item.arguments
+            if (
+                fixed_tuple_length := _fixed_tuple_annotation_length(
+                    annotation=argument.type_annotation,
+                )
+            )
+            is not None
+        }
+        for call in calls[first_body_call_index:]:
+            calls.fixed_tuple_lengths.setdefault(
+                call,
+                fixed_tuple_lengths,
+            )
+
+
+def _fixed_tuple_annotation_length(*, annotation: Type | None) -> int | None:
+    """Return the length of a fixed tuple annotation, if known."""
+    if not isinstance(annotation, UnboundType) or annotation.name not in {
+        "Tuple",
+        "builtins.tuple",
+        "tuple",
+        "typing.Tuple",
+    }:
+        return None
+    if not annotation.args or isinstance(annotation.args[-1], EllipsisType):
+        return None
+    return len(annotation.args)
 
 
 def _collect_call_exprs_from_expression(  # noqa: C901, PLR0912, PLR0915  # pylint: disable=too-complex,too-many-branches,too-many-statements
@@ -740,9 +803,9 @@ def _collect_call_exprs_from_pattern(
             assert_never(unreachable)
 
 
-def _iter_call_exprs(node: _CallExprContainer, /) -> list[CallExpr]:
+def _iter_call_exprs(node: _CallExprContainer, /) -> _CollectedCalls:
     """Return call expressions contained in a node."""
-    calls: list[CallExpr] = []
+    calls = _CollectedCalls()
     _collect_call_exprs(node, calls)
     return calls
 
@@ -808,6 +871,7 @@ def _check_super_method_call(
     expr: CallExpr,
     method_name: str,
     ignore_names: list[str],
+    fixed_tuple_lengths: dict[str, int],
 ) -> None:
     """Check one ``super()`` method call expression."""
     for info in _super_method_mro(ctx=ctx, expr=expr):
@@ -851,6 +915,7 @@ def _check_super_method_call(
             fullname=fullname,
             ignore_names=ignore_names,
             skip_bound_argument=skip_bound_argument,
+            fixed_tuple_lengths=fixed_tuple_lengths,
         ):
             ctx.api.fail(
                 msg=(
@@ -870,7 +935,8 @@ def _check_super_method_calls(
     ignore_names: list[str],
 ) -> None:
     """Check ``super()`` method calls in a class body."""
-    for expr in _iter_call_exprs(ctx.cls.defs):
+    calls = _iter_call_exprs(ctx.cls.defs)
+    for expr in calls:
         method_name = _super_method_name(expr=expr)
         if method_name is None:
             continue
@@ -879,6 +945,7 @@ def _check_super_method_calls(
             expr=expr,
             method_name=method_name,
             ignore_names=ignore_names,
+            fixed_tuple_lengths=calls.fixed_tuple_lengths.get(expr, {}),
         )
 
 

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -328,8 +328,8 @@
     Base().method(*args)
     Base().method(*(1,))
   out: |-
-    main:6: error: Too many positional arguments for "method" of "Base"  [misc]
-    main:7: error: Too many positional arguments for "method" of "Base"  [misc]
+    main:6: error: Too many positional arguments for "method" of "Base"  [call-arg]
+    main:7: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:18: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:19: error: Too many positional arguments for "method" of "Base"  [call-arg]
 

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -303,6 +303,35 @@
   out: |-
     main:6: error: Too many arguments for "method" of "B"  [call-arg]
 
+- case: super_method_fixed_tuple_unpacking
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, value: int) -> None: ...
+
+    class Child(Base):
+        def call(self, args: tuple[int]) -> None:
+            super().method(*args)
+            super().method(*(1,))
+
+    class VariadicBase:
+        def method(self, *values: int, option: int = 0) -> None: ...
+
+    class VariadicChild(VariadicBase):
+        def call(self, args: tuple[int, int]) -> None:
+            super().method(*args)
+
+    args = (1,)
+    Base().method(*args)
+    Base().method(*(1,))
+  out: |-
+    main:6: error: Too many positional arguments for "method" of "Base"  [misc]
+    main:7: error: Too many positional arguments for "method" of "Base"  [misc]
+    main:17: error: Too many positional arguments for "method" of "Base"  [call-arg]
+    main:18: error: Too many positional arguments for "method" of "Base"  [call-arg]
+
 - case: super_method_ignores_non_super_calls
   mypy_config: |
     [mypy]

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -315,6 +315,7 @@
         def call(self, args: tuple[int]) -> None:
             super().method(*args)
             super().method(*(1,))
+            super().method(*[1])
 
     class VariadicBase:
         def method(self, *values: int, option: int = 0) -> None: ...
@@ -329,8 +330,8 @@
   out: |-
     main:6: error: Too many positional arguments for "method" of "Base"  [misc]
     main:7: error: Too many positional arguments for "method" of "Base"  [misc]
-    main:17: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:18: error: Too many positional arguments for "method" of "Base"  [call-arg]
+    main:19: error: Too many positional arguments for "method" of "Base"  [call-arg]
 
 - case: super_method_ignores_non_super_calls
   mypy_config: |

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -333,6 +333,38 @@
     main:18: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:19: error: Too many positional arguments for "method" of "Base"  [call-arg]
 
+- case: super_method_fixed_tuple_unpacking_nested_scope
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, value: int) -> None: ...
+
+    class Child(Base):
+        def call(self, args: tuple[int]) -> None:
+            def inner() -> None:
+                super(Child, self).method(*args)
+
+            inner()
+  out: |-
+    main:7: error: Too many positional arguments for "method" of "Base"  [call-arg]
+
+- case: super_method_fixed_tuple_unpacking_inner_scope_shadows
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, value: int) -> None: ...
+
+    class Child(Base):
+        def call(self, args: tuple[int]) -> None:
+            def inner(args: list[int]) -> None:
+                super(Child, self).method(*args)
+
+            inner(args=[1])
+
 - case: super_method_ignores_non_super_calls
   mypy_config: |
     [mypy]


### PR DESCRIPTION
Closes #553.

## What changed

- Track fixed tuple lengths from function parameter annotations while traversing class bodies.
- Expand fixed tuple literals and fixed-tuple parameters in the manual super argument mapper.
- Keep unknown-length tuple unpacking conservative and preserve variadic positional formals.
- Add regression coverage and a changelog fragment.

## Why

The public typed call hooks are not invoked for super method calls, so the existing pre-type-check checker must retain the fixed arity information available in syntax and annotations.

## Validation

- uv run --extra=dev pytest -q (45 passed)
- repository pre-commit and pre-push checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the plugin’s AST walk and super-call validation; behavior changes only affect error reporting for unpacked super arguments, with new tests covering edge cases.
> 
> **Overview**
> Extends the **mypy_strict_kwargs** manual `super().method(...)` checker so `*args` is treated as multiple positional arguments when arity is known from syntax or annotations.
> 
> Call collection now uses **`_CollectedCalls`** to record, per call site, fixed-length tuple parameters (from `tuple[...]` / `Tuple[...]` annotations) and to respect inner-scope name shadowing. **`_call_disallows_positional_argument`** expands `ARG_STAR` via tuple literals, annotated fixed tuples, or stays conservative (0 extra positions) for lists and unknown unpacks; variadic `*values` formals still absorb expansions without false positives.
> 
> Regression YAML cases cover `super().method(*args)`, nested functions, and shadowed parameter names; changelog fragment added for #553.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d05f8628960b464ac201135c7a379ca7337dfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->