### PR TITLE
Scope protocol method exemptions to implicit calls

### DIFF
--- a/newsfragments/554.change
+++ b/newsfragments/554.change
@@ -1,0 +1,1 @@
+Restrict protocol-method positional exemptions to implicit calls.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -90,17 +90,33 @@ from mypy.types import CallableType, FunctionLike
 _CallExprContainer = Expression | Statement
 
 
-def _preserved_positional_argument_count(fullname: str) -> int:
-    """Return positional arguments to keep positional after method binding."""
-    # Some methods get called with positional arguments that callers do not
-    # supply explicitly.
-    if fullname.endswith((".__get__", ".__set__")):
-        # Descriptor attribute access and assignment.
-        return 2
-    if fullname.endswith(".__call__"):
-        # Called implicitly when an instance of the class is called.
-        return 1
-    return 0
+def _preserved_positional_argument_count(
+    ctx: FunctionSigContext | MethodSigContext,
+    fullname: str,
+) -> int:
+    """Return positional arguments used by an implicit protocol
+    operation.
+    """
+    if not isinstance(ctx, MethodSigContext):
+        return 0
+
+    protocol_argument_counts = {
+        "__call__": 1,
+        "__get__": 2,
+        "__set__": 2,
+    }
+    method_name = fullname.rsplit(".", maxsplit=1)[-1]
+    preserved_count = protocol_argument_counts.get(method_name, 0)
+    if preserved_count == 0:
+        return 0
+
+    context = ctx.context
+    if isinstance(context, CallExpr):
+        context = context.callee
+    if isinstance(context, MemberExpr) and context.name == method_name:
+        # An explicit ``obj.__call__(...)``-style access.
+        return 0
+    return preserved_count
 
 
 def _transform_signature(
@@ -119,6 +135,9 @@ def _transform_signature(
         fullname=fullname,
         ignore_names=ignore_names,
         skip_bound_argument=False,
+        preserved_positional_argument_count=(
+            _preserved_positional_argument_count(ctx, fullname)
+        ),
     )
 
 
@@ -128,6 +147,7 @@ def _transform_callable_type(
     fullname: str,
     ignore_names: list[str],
     skip_bound_argument: bool,
+    preserved_positional_argument_count: int,
 ) -> CallableType:
     """Transform positional arguments in a callable type."""
     new_arg_kinds: list[ArgKind] = []
@@ -140,9 +160,6 @@ def _transform_callable_type(
 
     first_star_arg_index = star_arg_indices[0] if star_arg_indices else None
 
-    preserved_positional_argument_count = _preserved_positional_argument_count(
-        fullname=fullname,
-    )
     skip_offset = 1 if skip_bound_argument else 0
     skip_indices = {
         index + skip_offset
@@ -245,6 +262,7 @@ def _call_disallows_positional_argument(
         fullname=fullname,
         ignore_names=ignore_names,
         skip_bound_argument=skip_bound_argument,
+        preserved_positional_argument_count=0,
     )
 
     positional_argument_index = 0

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -105,7 +105,7 @@ def _preserved_positional_argument_count(
         "__get__": 2,
         "__set__": 2,
     }
-    method_name = fullname.rsplit(".", maxsplit=1)[-1]
+    method_name = fullname.rsplit(sep=".", maxsplit=1)[-1]
     preserved_count = protocol_argument_counts.get(method_name, 0)
     if preserved_count == 0:
         return 0
@@ -136,7 +136,7 @@ def _transform_signature(
         ignore_names=ignore_names,
         skip_bound_argument=False,
         preserved_positional_argument_count=(
-            _preserved_positional_argument_count(ctx, fullname)
+            _preserved_positional_argument_count(ctx=ctx, fullname=fullname)
         ),
     )
 

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -750,6 +750,55 @@
     c.a
     c.a = 1
 
+- case: protocol_named_module_functions
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    def __call__(value: int) -> None: ...
+    def __get__(instance: object, owner: type[object] | None = None) -> None: ...
+    def __set__(instance: object, value: int) -> None: ...
+
+    __call__(1)
+    __get__(object(), object)
+    __set__(object(), 1)
+  out: |-
+    main:5: error: Too many positional arguments for "__call__"  [call-arg]
+    main:6: error: Too many positional arguments for "__get__"  [call-arg]
+    main:7: error: Too many positional arguments for "__set__"  [call-arg]
+
+- case: explicit_protocol_method_calls
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class ProtocolMethods:
+        def __call__(self, value: int) -> None: ...
+        def __get__(self, instance: object, owner: type[object] | None = None) -> None: ...
+        def __set__(self, instance: object, value: int) -> None: ...
+
+    methods = ProtocolMethods()
+    methods.__call__(1)
+    methods.__get__(object(), object)
+    methods.__set__(object(), 1)
+
+    call = methods.__call__
+    call(1)
+
+    class Child(ProtocolMethods):
+        def explicit_super_calls(self) -> None:
+            super().__call__(1)
+            super().__get__(object(), object)
+            super().__set__(object(), 1)
+  out: |-
+    main:7: error: Too many positional arguments for "__call__" of "ProtocolMethods"  [call-arg]
+    main:8: error: Too many positional arguments for "__get__" of "ProtocolMethods"  [call-arg]
+    main:9: error: Too many positional arguments for "__set__" of "ProtocolMethods"  [call-arg]
+    main:12: error: Too many positional arguments  [call-arg]
+    main:16: error: Too many positional arguments for "__call__" of "ProtocolMethods"  [misc]
+    main:17: error: Too many positional arguments for "__get__" of "ProtocolMethods"  [misc]
+    main:18: error: Too many positional arguments for "__set__" of "ProtocolMethods"  [misc]
+
 - case: ignore_name
   files:
     - path: pyproject.toml

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -795,9 +795,9 @@
     main:8: error: Too many positional arguments for "__get__" of "ProtocolMethods"  [call-arg]
     main:9: error: Too many positional arguments for "__set__" of "ProtocolMethods"  [call-arg]
     main:12: error: Too many positional arguments  [call-arg]
-    main:16: error: Too many positional arguments for "__call__" of "ProtocolMethods"  [misc]
-    main:17: error: Too many positional arguments for "__get__" of "ProtocolMethods"  [misc]
-    main:18: error: Too many positional arguments for "__set__" of "ProtocolMethods"  [misc]
+    main:16: error: Too many positional arguments for "__call__" of "ProtocolMethods"  [call-arg]
+    main:17: error: Too many positional arguments for "__get__" of "ProtocolMethods"  [call-arg]
+    main:18: error: Too many positional arguments for "__set__" of "ProtocolMethods"  [call-arg]
 
 - case: ignore_name
   files:


### PR DESCRIPTION
## Summary
- distinguish implicit protocol operations from explicit method syntax using mypy hook context
- enforce keyword arguments for module-level and explicit `__call__`, `__get__`, and `__set__` calls
- retain positional compatibility for callable objects, decorators, and descriptor access

## Testing
- `uv run --extra=dev --python=3.12 pytest -q --cov-fail-under 100 --cov=src/ --cov=tests/ .`
- `uv run --extra=dev prek run --all-files`
- `uv run --extra=dev prek run pylint --all-files --hook-stage manual`
- `uv run --extra=dev prek run --all-files --hook-stage pre-push`

Closes #554

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mypy signature behavior for dunder-named callables and may surface new `call-arg` errors in code that relied on the old blanket exemption.
> 
> **Overview**
> **Tightens** when `mypy_strict_kwargs` keeps positional arguments allowed for `__call__`, `__get__`, and `__set__`: exemptions apply only to **implicit** protocol use (e.g. calling an instance, descriptor read/write), not to every method with those names.
> 
> `_preserved_positional_argument_count` now takes the mypy signature hook context. It skips preservation for module-level functions (`FunctionSigContext`) and for **explicit** `obj.__call__(...)` / `__get__` / `__set__` syntax (detected via `MemberExpr` on the call callee). Implicit cases still preserve the same slot counts as before (1 for `__call__`, 2 for `__get__` / `__set__`). The preserved count is threaded into `_transform_callable_type` from signature transformation; call-site positional checks continue to pass `0` so super-call validation is unchanged.
> 
> Adds YAML cases for module-level dunder-named functions and explicit protocol method calls, plus a newsfragment for #554.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac09cc5a37820993c871628b7da3c90b6c76ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->