### PR TITLE
Invalidate incremental caches for plugin config changes

### DIFF
--- a/newsfragments/555.change
+++ b/newsfragments/555.change
@@ -1,0 +1,1 @@
+Invalidate mypy's incremental cache when plugin configuration changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,7 @@ ignore_names = [
     "get_base_class_hook",
     "get_function_signature_hook",
     "get_method_signature_hook",
+    "report_config_data",
 ]
 
 [tool.pyproject-fmt]

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -79,6 +79,7 @@ from mypy.plugin import (
     FunctionSigContext,
     MethodSigContext,
     Plugin,
+    ReportConfigContext,
 )
 from mypy.types import CallableType, FunctionLike
 
@@ -805,6 +806,14 @@ class KeywordOnlyPlugin(Plugin):
                         fallback=False,
                     )
                 )
+
+    def report_config_data(self, ctx: ReportConfigContext) -> object:
+        """Return plugin configuration that affects cached modules."""
+        del ctx
+        return {
+            "debug": self._debug,
+            "ignore_names": self._ignore_names,
+        }
 
     def get_function_signature_hook(
         self,

--- a/tests/test_incremental_cache.py
+++ b/tests/test_incremental_cache.py
@@ -1,0 +1,49 @@
+"""Tests for incremental cache invalidation."""
+
+from pathlib import Path
+
+from mypy import api
+
+
+def test_plugin_configuration_invalidates_cache(tmp_path: Path) -> None:
+    """Changing plugin options rechecks otherwise fresh modules."""
+    source_path = tmp_path / "example.py"
+    source_path.write_text(
+        data="def function(value: int) -> None: ...\n\nfunction(1)\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "mypy.ini"
+    config_path.write_text(
+        data=(
+            "[mypy]\n"
+            "plugins = mypy_strict_kwargs\n"
+            "strict = true\n\n"
+            "[mypy_strict_kwargs]\n"
+            "ignore_names = example.function\n"
+        ),
+        encoding="utf-8",
+    )
+    arguments = [
+        "--cache-dir",
+        str(object=tmp_path / ".mypy_cache"),
+        "--config-file",
+        str(object=config_path),
+        str(object=source_path),
+    ]
+
+    first_stdout, first_stderr, first_status = api.run(args=arguments)
+
+    assert first_status == 0
+    assert first_stderr == ""
+    assert "Success: no issues found" in first_stdout
+
+    config_path.write_text(
+        data=("[mypy]\nplugins = mypy_strict_kwargs\nstrict = true\n"),
+        encoding="utf-8",
+    )
+
+    second_stdout, second_stderr, second_status = api.run(args=arguments)
+
+    assert second_status == 1
+    assert second_stderr == ""
+    assert 'Too many positional arguments for "function"' in second_stdout


### PR DESCRIPTION
## Summary
- report `ignore_names` and `debug` through mypy’s plugin cache metadata hook
- add an integration test that changes only plugin configuration between incremental runs
- register the mypy hook name with the repository’s Vulture configuration

## Testing
- `uv run --extra=dev --python=3.12 pytest -q --cov-fail-under 100 --cov=src/ --cov=tests/ .`
- `uv run --extra=dev prek run --all-files`
- `uv run --extra=dev prek run pylint --all-files --hook-stage manual`
- `uv run --extra=dev prek run --all-files --hook-stage pre-push`

Closes #555

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standard mypy plugin cache-metadata hook and a test; behavior change is limited to correct incremental invalidation when plugin options change.
> 
> **Overview**
> Fixes stale incremental results when only **`mypy_strict_kwargs`** options change (e.g. **`ignore_names`** or **`debug`**), without edits to source files.
> 
> The plugin now implements mypy’s **`report_config_data`** hook and returns those settings so the cache treats a config change as a reason to recheck affected modules. An integration test runs mypy twice with the same cache: first with **`ignore_names`** allowing a positional call, then without it, and expects the second run to report the strict-kwargs error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb61d58b0560ef6d09d60e923073d9c5a3dfbd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->