### PR TITLE
Check assigned staticmethods in super calls

### DIFF
--- a/newsfragments/556.change
+++ b/newsfragments/556.change
@@ -1,0 +1,1 @@
+Check ``super()`` calls to methods assigned through ``staticmethod()``.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -8,7 +8,7 @@ from functools import partial
 from pathlib import Path
 from typing import assert_never
 
-from mypy.errorcodes import MISC
+from mypy.errorcodes import CALL_ARG
 from mypy.nodes import (
     REVEAL_TYPE,
     ArgKind,
@@ -833,7 +833,7 @@ def _check_super_method_call(
                     f'of "{info.name}"'
                 ),
                 ctx=expr,
-                code=MISC,
+                code=CALL_ARG,
             )
             return
         return

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -53,12 +53,14 @@ from mypy.nodes import (
     StarExpr,
     Statement,
     SuperExpr,
+    SymbolNode,
     TemplateStrExpr,
     TryStmt,
     TupleExpr,
     TypeApplication,
     TypeInfo,
     UnaryExpr,
+    Var,
     WhileStmt,
     WithStmt,
     YieldExpr,
@@ -726,6 +728,56 @@ def _iter_call_exprs(node: _CallExprContainer, /) -> list[CallExpr]:
     return calls
 
 
+def _assigned_staticmethod_target(
+    *,
+    class_def: ClassDef,
+    method_name: str,
+) -> FuncDef | OverloadedFuncDef | Decorator | None:
+    """Return the callable wrapped by an assigned ``staticmethod``."""
+    for statement in class_def.defs.body:
+        match statement:
+            case AssignmentStmt(
+                lvalues=[NameExpr(name=name)],
+                rvalue=CallExpr(
+                    callee=NameExpr(fullname="builtins.staticmethod"),
+                    args=[
+                        NameExpr(
+                            node=(
+                                FuncDef() | OverloadedFuncDef() | Decorator()
+                            ) as target
+                        )
+                    ],
+                ),
+            ) if name == method_name:
+                return target
+            case _:
+                continue
+    return None
+
+
+def _resolved_super_member_node(
+    *,
+    node: SymbolNode | None,
+    class_def: ClassDef,
+    method_name: str,
+) -> tuple[
+    FuncDef | OverloadedFuncDef | Decorator | None,
+    str | None,
+]:
+    """Resolve a supported member node and its assigned full name."""
+    if isinstance(node, Var):
+        return (
+            _assigned_staticmethod_target(
+                class_def=class_def,
+                method_name=method_name,
+            ),
+            node.fullname,
+        )
+    if isinstance(node, FuncDef | OverloadedFuncDef | Decorator):
+        return node, None
+    return None, None
+
+
 def _check_super_method_call(
     *,
     ctx: ClassDefContext,
@@ -739,16 +791,26 @@ def _check_super_method_call(
         if symbol is None:
             continue
 
-        node = symbol.node
+        node, assigned_fullname = _resolved_super_member_node(
+            node=symbol.node,
+            class_def=info.defn,
+            method_name=method_name,
+        )
+
         match node:
             case FuncDef() | OverloadedFuncDef():
-                fullname = node.fullname
+                fullname = assigned_fullname or node.fullname
                 typ = node.type
-                skip_bound_argument = node.has_self_or_cls_argument
+                skip_bound_argument = (
+                    assigned_fullname is None and node.has_self_or_cls_argument
+                )
             case Decorator():
-                fullname = node.fullname
+                fullname = assigned_fullname or node.fullname
                 typ = node.func.type
-                skip_bound_argument = node.func.has_self_or_cls_argument
+                skip_bound_argument = (
+                    assigned_fullname is None
+                    and node.func.has_self_or_cls_argument
+                )
             case _:
                 return
 

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -349,6 +349,14 @@
     class C(B):
         def call(self) -> None:
             super().method()
+
+    class NestedBase:
+        class factory:
+            pass
+
+    class NestedChild(NestedBase):
+        def call(self) -> None:
+            super().factory()
   out: |-
     main:6: error: "int" not callable  [operator]
 
@@ -388,6 +396,25 @@
             super().method(1)
   out: |-
     main:7: error: Too many positional arguments for "method" of "B"  [misc]
+
+- case: super_method_assigned_staticmethod
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    def implementation(value: int) -> None: ...
+
+    class B:
+        method = staticmethod(implementation)
+
+    class C(B):
+        def call(self) -> None:
+            super().method(1)
+
+    B().method(1)
+  out: |-
+    main:8: error: Too many positional arguments for "method" of "B"  [misc]
+    main:10: error: Too many positional arguments  [call-arg]
 
 - case: super_method_no_type_check_decorated_base_method
   disable_cache: true

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -123,7 +123,7 @@
         def method(self, a: int) -> None:
             super().method(1)
   out: |-
-    main:6: error: Too many positional arguments for "method" of "B"  [misc]
+    main:6: error: Too many positional arguments for "method" of "B"  [call-arg]
 
 - case: super_method_ignore_name
   mypy_config: |
@@ -162,7 +162,7 @@
         def call(self) -> int:
             return super().method(1)
   out: |-
-    main:5: error: Too many positional arguments for "method" of "B"  [misc]
+    main:5: error: Too many positional arguments for "method" of "B"  [call-arg]
 
 - case: super_method_explicit_super
   mypy_config: |
@@ -176,7 +176,7 @@
         def method(self, a: int) -> None:
             super(C, self).method(1)
   out: |-
-    main:6: error: Too many positional arguments for "method" of "B"  [misc]
+    main:6: error: Too many positional arguments for "method" of "B"  [call-arg]
 
 - case: super_method_explicit_super_from_base
   mypy_config: |
@@ -208,7 +208,7 @@
             classes = (B,)
             super(classes[0], self).method(1)
   out: |-
-    main:7: error: Too many positional arguments for "method" of "B"  [misc]
+    main:7: error: Too many positional arguments for "method" of "B"  [call-arg]
     main:7: error: "method" undefined in superclass  [misc]
 
 # Fall back when the first argument name does not resolve to a type.
@@ -226,7 +226,7 @@
         def method(self, a: int) -> None:
             super(x, self).method(1)
   out: |-
-    main:8: error: Too many positional arguments for "method" of "B"  [misc]
+    main:8: error: Too many positional arguments for "method" of "B"  [call-arg]
     main:8: error: Argument 1 for "super" must be a type object; got a non-type instance  [arg-type]
 
 # Fall back when the explicit type is not in the current class MRO.
@@ -245,7 +245,7 @@
         def method(self, a: int) -> None:
             super(Unrelated, self).method(1)
   out: |-
-    main:9: error: Too many positional arguments for "method" of "B"  [misc]
+    main:9: error: Too many positional arguments for "method" of "B"  [call-arg]
     main:9: error: Argument 2 for "super" not an instance of argument 1  [misc]
 
 - case: super_method_keyword_argument
@@ -380,7 +380,7 @@
         def method(self, a: int) -> None:
             super().method(1)
   out: |-
-    main:14: error: Too many positional arguments for "method" of "B"  [misc]
+    main:14: error: Too many positional arguments for "method" of "B"  [call-arg]
 
 - case: super_method_staticmethod
   mypy_config: |
@@ -395,7 +395,7 @@
         def call(self) -> None:
             super().method(1)
   out: |-
-    main:7: error: Too many positional arguments for "method" of "B"  [misc]
+    main:7: error: Too many positional arguments for "method" of "B"  [call-arg]
 
 - case: super_method_assigned_staticmethod
   mypy_config: |
@@ -413,7 +413,7 @@
 
     B().method(1)
   out: |-
-    main:8: error: Too many positional arguments for "method" of "B"  [misc]
+    main:8: error: Too many positional arguments for "method" of "B"  [call-arg]
     main:10: error: Too many positional arguments  [call-arg]
 
 - case: super_method_no_type_check_decorated_base_method


### PR DESCRIPTION
## Summary
- resolve class attributes assigned through `staticmethod(...)` to their wrapped callable during manual `super()` checks
- preserve the assigned attribute full name and avoid treating the wrapped callable as bound
- retain safe handling for non-callable and unsupported class members

## Testing
- `uv run --extra=dev --python=3.12 pytest -q --cov-fail-under 100 --cov=src/ --cov=tests/ .`
- `uv run --extra=dev prek run --all-files`
- `uv run --extra=dev prek run pylint --all-files --hook-stage manual`
- `uv run --extra=dev prek run --all-files --hook-stage pre-push`

Closes #556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to plugin super()-call analysis and error-code alignment; behavior change is intentional for assigned staticmethods and clearer diagnostics.
> 
> **Overview**
> Extends the mypy strict-kwargs plugin so **`super().method(...)`** checks work when the base defines the method as **`method = staticmethod(implementation)`**, not only with **`@staticmethod`**.
> 
> The plugin now scans the base class body for that assignment pattern, resolves the wrapped callable for arity/keyword-only rules, uses the **attribute’s full name** for `ignore_names`, and treats the call as **unbound** (no implicit `self` skip). Unsupported or non-callable members are unchanged.
> 
> Super-call positional-argument diagnostics now use mypy’s **`call-arg`** code instead of **`misc`**, with tests updated accordingly (including a new assigned-`staticmethod` case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab8ebbaf93b537efa65e517e8e9e115e7a767cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->