### PR TITLE
Check super() positional args from list literal unpacking

### DIFF
--- a/newsfragments/567.change
+++ b/newsfragments/567.change
@@ -1,0 +1,2 @@
+Check positional arguments supplied to ``super()`` methods by unpacking
+list literals.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -309,7 +309,7 @@ def _call_disallows_positional_argument(
         if actual_arg_kind == ArgKind.ARG_POS:
             positional_argument_count = 1
         elif actual_arg_kind == ArgKind.ARG_STAR:
-            if isinstance(actual_arg, TupleExpr):
+            if isinstance(actual_arg, TupleExpr | ListExpr):
                 # Only the items before a nested ``*spread`` occupy known
                 # positions; the spread itself has no statically known
                 # length, so anything after it cannot be placed.

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -330,6 +330,7 @@
   out: |-
     main:6: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:7: error: Too many positional arguments for "method" of "Base"  [call-arg]
+    main:8: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:18: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:19: error: Too many positional arguments for "method" of "Base"  [call-arg]
 
@@ -358,6 +359,48 @@
             super().method(*(1, *rest))
   out: |-
     main:6: error: Too many positional arguments for "method" of "Base"  [call-arg]
+
+- case: super_method_list_literal_unpacking
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, value: int) -> None: ...
+
+    class Child(Base):
+        def call(self) -> None:
+            super().method(*[1])
+            super().method(*[1, 2])
+  out: |-
+    main:6: error: Too many positional arguments for "method" of "Base"  [call-arg]
+    main:7: error: Too many positional arguments for "method" of "Base"  [call-arg]
+
+- case: super_method_list_literal_star_spread
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, a: int, /, b: int = 0) -> None: ...
+
+    class Child(Base):
+        def call(self, rest: tuple[int, ...]) -> None:
+            super().method(*[1, *rest])
+
+- case: super_method_unpacking_unknown_expression
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, value: int) -> None: ...
+
+    class Child(Base):
+        data: tuple[int, ...]
+
+        def call(self) -> None:
+            super().method(*self.data)
 
 - case: super_method_fixed_tuple_unpacking_nested_scope
   mypy_config: |


### PR DESCRIPTION
Fixes #567.

The manual `super()` positional-argument check handled `*`-unpacking of a **tuple literal** (`*(1,)`) but silently ignored a **list literal** of the same statically known length (`*[1]`), even though mypy flags the equivalent regular call. The `ARG_STAR` branch of `_call_disallows_positional_argument` now treats `ListExpr` like `TupleExpr`.

## Reproduction (now flagged)
```python
class Base:
    def method(self, value: int) -> None: ...

class Child(Base):
    def call(self) -> None:
        super().method(*[1])   # now: Too many positional arguments for "method" of "Base"
```

## Notes
- Touches the same `ARG_STAR` branch as #568 (nested-star spread), so the two PRs overlap; whichever merges second will need a trivial rebase.

## Testing
- `pytest --cov-fail-under 100` (100% coverage, 60 passed)
- `pyrefly check` (0 errors), `pylint` (10.00/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to super() call analysis in the mypy plugin; no auth, data, or runtime behavior impact.
> 
> **Overview**
> Fixes a gap where **`super().method(*[1])`** could slip past the plugin’s manual positional-argument check even though the same call on a normal method is flagged.
> 
> In **`_call_disallows_positional_argument`**, the `ARG_STAR` path already counted positions for **tuple literals** (`*(1,)`) via `_leading_positional_count`; it now does the same for **list literals** (`*[1]`, including nested `*[1, *rest]`). Non-literal unpacks are unchanged.
> 
> Tests extend the fixed-tuple unpacking case to expect an error for `*[1]` and add YAML cases for list unpacking, list star-spread, and unknown expressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72901c2e2ba3a79d87c5bca28856eab332d09fef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->