### PR TITLE
Fix false positive for super() star spread in tuple literal

### DIFF
--- a/newsfragments/568.change
+++ b/newsfragments/568.change
@@ -1,0 +1,2 @@
+Stop reporting false positives for ``super()`` methods called with a
+tuple literal that unpacks a variable-length ``*`` spread.

--- a/src/mypy_strict_kwargs/plugin.py
+++ b/src/mypy_strict_kwargs/plugin.py
@@ -268,6 +268,20 @@ def _super_method_mro(
     return ctx.cls.info.mro[super_type_index + 1 :]
 
 
+def _leading_positional_count(*, items: list[Expression]) -> int:
+    """Return the number of items before the first ``*`` spread.
+
+    A ``*spread`` inside a sequence literal has no statically known length,
+    so only the items preceding it occupy known positions.
+    """
+    leading_count = 0
+    for item in items:
+        if isinstance(item, StarExpr):
+            break
+        leading_count += 1
+    return leading_count
+
+
 def _call_disallows_positional_argument(
     *,
     call: CallExpr,
@@ -296,7 +310,12 @@ def _call_disallows_positional_argument(
             positional_argument_count = 1
         elif actual_arg_kind == ArgKind.ARG_STAR:
             if isinstance(actual_arg, TupleExpr):
-                positional_argument_count = len(actual_arg.items)
+                # Only the items before a nested ``*spread`` occupy known
+                # positions; the spread itself has no statically known
+                # length, so anything after it cannot be placed.
+                positional_argument_count = _leading_positional_count(
+                    items=actual_arg.items,
+                )
             elif isinstance(actual_arg, NameExpr):
                 positional_argument_count = fixed_tuple_lengths.get(
                     actual_arg.name,

--- a/tests/test_plugin.yaml
+++ b/tests/test_plugin.yaml
@@ -333,6 +333,32 @@
     main:18: error: Too many positional arguments for "method" of "Base"  [call-arg]
     main:19: error: Too many positional arguments for "method" of "Base"  [call-arg]
 
+- case: super_method_star_spread_in_tuple_literal
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, a: int, /, b: int = 0) -> None: ...
+
+    class Child(Base):
+        def call(self, rest: tuple[int, ...]) -> None:
+            super().method(*(1, *rest))
+
+- case: super_method_star_spread_checks_leading_items
+  mypy_config: |
+    [mypy]
+    plugins = mypy_strict_kwargs
+  main: |-
+    class Base:
+        def method(self, value: int) -> None: ...
+
+    class Child(Base):
+        def call(self, rest: tuple[int, ...]) -> None:
+            super().method(*(1, *rest))
+  out: |-
+    main:6: error: Too many positional arguments for "method" of "Base"  [call-arg]
+
 - case: super_method_fixed_tuple_unpacking_nested_scope
   mypy_config: |
     [mypy]


### PR DESCRIPTION
Fixes #568.

The manual `super()` check counted the elements of a `*`-unpacked tuple literal with `len(items)`, counting a nested variable-length `*spread` as a single element. `super().m(*(1, *rest))` was wrongly reported as passing too many positional arguments even though `(1, *rest)` has no statically known length.

`_call_disallows_positional_argument` now counts only the items **before the first spread** (via a new `_leading_positional_count` helper), whose positions are statically known. This removes the false positive while still checking those leading items — e.g. `super().method(*(1, *rest))` where the first parameter is keyword-only is still correctly flagged (the concrete `1` is definitely positional).

## Reproduction (no longer flagged)
```python
class Base:
    def method(self, a: int, /, b: int = 0) -> None: ...

class Child(Base):
    def call(self, rest: tuple[int, ...]) -> None:
        super().method(*(1, *rest))   # was: false "Too many positional arguments"
```

## Notes
- Touches the same `ARG_STAR` branch as #569 (list-literal unpacking), so the two PRs overlap; whichever merges second will need a trivial rebase.

## Testing
- `pytest --cov-fail-under 100` (100% coverage, 60 passed)
- `pyrefly check` (0 errors), `pylint` (10.00/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to super() positional-argument simulation for tuple star-unpacks; covered by new plugin tests with no auth or runtime behavior impact.
> 
> **Overview**
> Fixes a **false positive** in the mypy strict-kwargs plugin when checking `super().method(...)` calls that unpack a tuple literal containing a variable-length `*rest` spread.
> 
> Previously, `*`-unpacking a tuple like `*(1, *rest)` was treated as contributing **two** known positional slots (`len(items)`), so calls such as `super().method(*(1, *rest))` could be flagged even when the unpacked sequence has no static length. **`_call_disallows_positional_argument`** now uses **`_leading_positional_count`** so only elements **before the first nested `*`** count toward positional placement; anything after a spread is ignored for static counting.
> 
> Valid variadic super calls are no longer reported incorrectly, while **leading** literals are still checked—for example `super().method(*(1, *rest))` still errors when the base method only accepts keyword arguments after `self`, because the leading `1` is known positional.
> 
> Adds YAML regression cases and a newsfragment for #568.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af0108c9e773328a1560280b4e53573ebc8d4ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->