### PR TITLE
Switch Vale to the upstream ai-tells package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -300,7 +300,7 @@ repos:
 
       # Vale enforces prose style rules, such as banning em dashes, in
       # reStructuredText and Markdown files.
-      # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
+      # The rules come from the ``ai-tells`` package pinned in ``.vale.ini``,
       # which ``vale sync`` downloads into the (gitignored) ``styles``
       # directory.
       # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,12 @@
 StylesPath = styles
 MinAlertLevel = error
 
-Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.29.0/ai-tells.zip
 
 [*.{rst,md}]
-BasedOnStyles = ClearProse
+BasedOnStyles = ai-tells
+
+# These rules misclassify established technical, example, or release-note prose
+# in this repository. All other ai-tells rules remain enforced.
+ai-tells.CataphoricForecasting = NO
+ai-tells.FormalTransitions = NO


### PR DESCRIPTION
## What changed

- Replace the single-rule `ClearProse` package with [`tbhb/vale-ai-tells`](https://github.com/tbhb/vale-ai-tells) v1.29.0.
- Keep all compatible ai-tells rules enabled.
- Disable only rules that flag established technical, example, or release-note prose already present in this repository.
- Update the Vale workflow/hook comment where one names the old package.

## Why

The upstream package covers em dashes as well as a much broader set of patterns associated with AI-written prose. Repository-specific exceptions avoid rewriting valid technical terminology and reference material merely to satisfy a general-audience heuristic.

## Validation

- `uvx --with docutils vale@3.13.0.0` over every tracked `*.rst` and `*.md` file
- Result: passed with zero errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linting/config-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Replaces the custom `ClearProse` Vale package with upstream `ai-tells` v1.29.0 for broader AI-prose detection in `*.rst` and `*.md` files.
> 
> Disables only `CataphoricForecasting` and `FormalTransitions`, which misclassify existing technical and release-note prose. Updates the pre-commit comment to name the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5f7275f84cb8ab670db08fb7905c3683cce443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->