### PR TITLE
Bump August dependency releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
-    "doccmd==2026.7.19",
+    "doccmd==2026.8.16",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "no-defaults==2.1.0",


### PR DESCRIPTION
Updates the newly released internal dependencies to their latest August 2026 versions.\n\nThis keeps the development and test toolchain on the released implementations and refreshes the uv lockfile.\n\nValidation: `uv lock` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only tooling version bump with no runtime or library API changes.
> 
> **Overview**
> Bumps the **dev** optional dependency **`doccmd`** from `2026.7.19` to **`2026.8.16`** in `pyproject.toml`, aligning the doc-extraction toolchain used by pre-commit (`shellcheck-docs`, `mypy-docs`, `pyright-docs`, etc.) with the August 2026 release.
> 
> Expect the **uv lockfile** to be refreshed alongside this pin so CI and local `uv sync --extra dev` resolve the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d46eaa7587acc9025a27cc4999ebdd1efac6666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->